### PR TITLE
Add reservation availability validation and token expiry handling

### DIFF
--- a/assets/js/tracking-bootstrap.js
+++ b/assets/js/tracking-bootstrap.js
@@ -1,0 +1,4 @@
+(function(window){
+    window.fpResvTracking = window.fpResvTracking || {};
+    window.fpResvTracking.dispatch = window.fpResvTracking.dispatch || function(){ return null; };
+})(window);

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,9 @@
   ],
   "require": {
     "php": ">=8.1"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9",
+    "dg/bypass-finals": "^1.9"
   }
 }

--- a/docs/FUTURE-IMPROVEMENTS.md
+++ b/docs/FUTURE-IMPROVEMENTS.md
@@ -1,5 +1,7 @@
 # Future Improvement Tasks
 
+This list reflects the current codebase as of the latest repository refresh, ensuring the suggestions remain compatible with the present implementation.
+
 Below are ten proposed enhancements for the plugin, captured as actionable task stubs for future pull requests.
 
 :::task-stub{title="Add REST parameter schema for reservation creation"}

--- a/docs/FUTURE-IMPROVEMENTS.md
+++ b/docs/FUTURE-IMPROVEMENTS.md
@@ -1,0 +1,63 @@
+# Future Improvement Tasks
+
+Below are ten proposed enhancements for the plugin, captured as actionable task stubs for future pull requests.
+
+:::task-stub{title="Add REST parameter schema for reservation creation"}
+- In `src/Domain/Reservations/REST.php`, extend the `/reservations` route registration so the `args` key lists every accepted field (date, time, party, contact fields, consent flags, etc.) with appropriate `sanitize_callback`/`validate_callback`.
+- Where useful, reuse the existing `param()` helper or dedicated static callbacks to keep sanitization logic consistent with `handleCreateReservation`.
+- Update or add integration tests under `tests/Integration/Reservations/RestTest.php` to cover success and failure paths when required arguments are missing or invalid, ensuring the new schema works as intended.
+:::
+
+:::task-stub{title="Introduce configurable management capability"}
+- Create a single helper (e.g., `Security::managementCapability()`) that returns a filterable capability string with `manage_options` as the default, and use it in `Security::currentUserCanManage()`.
+- Replace every direct `'manage_options'` reference across admin controllers and REST permission callbacks (Reservations, Tables, Closures, Reports, Diagnostics, QA, etc.) with the new helper result.
+- Document the filter name in the README so administrators know how to override the capability for custom roles.
+:::
+
+:::task-stub{title="Wire up script translations"}
+- After registering/enqueuing the frontend handles in `src/Frontend/WidgetController.php::enqueueAssets()`, call `wp_set_script_translations()` for `fp-resv-onepage-module` (and the legacy handle if kept) using the `fp-restaurant-reservations` text domain and the plugin languages directory.
+- Repeat the same for each admin JS entry point (agenda, tables, closures, reports, settings, etc.) right after their `wp_enqueue_script()` calls so those bundles can load translated strings.
+- Ensure the build pipeline produces the matching `*.json` files under `languages/` and adjust any documentation that lists build prerequisites.
+:::
+
+:::task-stub{title="Add filters for REST rate limits"}
+- In `src/Domain/Reservations/REST.php`, wrap the magic numbers used in the `RateLimiter::allow()` calls with filters like `fp_resv_rate_limit_availability` and `fp_resv_rate_limit_reservations`, passing the limit, window seconds, and request context.
+- Apply the filtered values when setting `Retry-After` headers so clients get consistent guidance.
+- Document the new filters (README or docs/QA) with example snippets for raising or lowering the thresholds.
+:::
+
+:::task-stub{title="Refine reservation query by room"}
+- Update `loadReservations()` in `src/Domain/Reservations/Availability.php` to append a prepared `AND room_id = %d` clause (and binding) when `$roomId` is supplied, instead of filtering after the query.
+- Keep the current behaviour for reservations without a room assignment (so global counts still work) by adjusting the SQL logic accordingly.
+- Verify availability responses through integration tests (or new ones) to confirm the results stay unchanged while query performance improves.
+:::
+
+:::task-stub{title="Introduce Availability service integration tests"}
+- Create a new test case (e.g., `tests/Integration/Reservations/AvailabilityTest.php`) that boots the `Availability` service with a fake `$wpdb` dataset covering multiple rooms, closures, and overlapping reservations.
+- Assert that the service returns blocked/full/available statuses, respects waitlist flags, and applies closure capacity reductions as expected.
+- Include regression tests for tricky inputs (invalid dates, party sizes) to complement the service’s input validation.
+:::
+
+:::task-stub{title="Translate reservation validation exceptions"}
+- Replace the hard-coded exception messages in `assertPayload()` with calls to `__()` using the plugin text domain, keeping the exception types intact.
+- Update any tests that assert on exact strings to expect the translated versions (or use translation helpers to keep tests locale-agnostic).
+- Scan nearby validation paths for similar plain-English strings and bring them into the translation system for consistency.
+:::
+
+:::task-stub{title="Localise domain runtime exceptions"}
+- Wrap each user-facing `RuntimeException`/`InvalidArgumentException` message in the affected services (`src/Domain/Payments/StripeService.php`, `src/Domain/Closures/Service.php`, `src/Domain/Tables/LayoutService.php`, etc.) with `__()` and the plugin text domain.
+- For formatted strings (e.g., Stripe API errors), ensure placeholders remain intact and translators can understand the context by adding translator comments if necessary.
+- Add regression tests or adjust existing ones so they no longer rely on exact English strings, instead checking codes or using translation helpers.
+:::
+
+:::task-stub{title="Add Retry-After to reservation throttling response"}
+- In `src/Domain/Reservations/REST.php::handleCreateReservation()`, convert the rate-limit branch to return a `WP_REST_Response` (or modify the error) with a `Retry-After` header matching the cooldown window.
+- Mirror the header logic in any other rate-limited endpoints (e.g., QA seeder) for consistent client behaviour.
+- Extend the REST tests to confirm the header is emitted alongside the 429 status.
+:::
+
+:::task-stub{title="Cover StripeService amount logic in tests"}
+- Add a dedicated test class (e.g., `tests/Unit/Payments/StripeServiceTest.php`) that exercises `calculateReservationAmount()`, `shouldRequireReservationPayment()`, and `toMinorUnits()` under different capture strategies, deposits, and zero-decimal currencies.
+- Mock the repository dependency so tests can focus purely on computation without hitting the database.
+- Ensure the new tests guard against regressions when Stripe settings or pricing rules change.
+:::

--- a/src/Core/Logging.php
+++ b/src/Core/Logging.php
@@ -4,11 +4,46 @@ declare(strict_types=1);
 
 namespace FP\Resv\Core;
 
+use FP\Resv\Domain\Diagnostics\Logger as DiagnosticsLogger;
+use Throwable;
+use function error_log;
+use function is_string;
+use function wp_json_encode;
+
 final class Logging
 {
     public static function log(string $channel, string $message, array $context = []): void
     {
-        // @todo Implement logging strategy (database tables / WP logger).
+        $container = ServiceContainer::getInstance();
+        $logger    = $container->get(DiagnosticsLogger::class);
+
+        if ($logger instanceof DiagnosticsLogger) {
+            try {
+                $logger->log($channel, $message, $context);
+            } catch (Throwable $exception) {
+                error_log(self::formatFallback($channel, $message, $context, $exception));
+            }
+        } else {
+            error_log(self::formatFallback($channel, $message, $context));
+        }
+
         do_action('fp_resv_log', $channel, $message, $context);
+    }
+
+    private static function formatFallback(string $channel, string $message, array $context, ?Throwable $exception = null): string
+    {
+        $payload = [
+            'channel' => $channel,
+            'message' => $message,
+            'context' => $context,
+        ];
+
+        if ($exception !== null) {
+            $payload['error'] = $exception->getMessage();
+        }
+
+        $encoded = wp_json_encode($payload);
+
+        return is_string($encoded) ? '[fp-resv] ' . $encoded : '[fp-resv] ' . $channel . ': ' . $message;
     }
 }

--- a/src/Core/REST.php
+++ b/src/Core/REST.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Resv\Core;
 
 use DateTimeImmutable;
+use FP\Resv\Core\Security;
 use DateTimeZone;
 use WP_Error;
 use WP_REST_Request;
@@ -12,7 +13,6 @@ use WP_REST_Response;
 use WP_REST_Server;
 use function __;
 use function add_action;
-use function current_user_can;
 use function esc_html;
 use function esc_html__;
 use function get_bloginfo;
@@ -39,7 +39,7 @@ final class REST
             [
                 'methods'             => WP_REST_Server::CREATABLE,
                 'callback'            => [self::class, 'handleEmailTest'],
-                'permission_callback' => static fn (): bool => current_user_can('manage_options'),
+                'permission_callback' => static fn (): bool => Security::currentUserCanManage(),
                 'args'                => [
                     'email' => [
                         'type'     => 'string',
@@ -59,7 +59,7 @@ final class REST
             [
                 'methods'             => WP_REST_Server::READABLE,
                 'callback'            => [self::class, 'handlePrivacyExport'],
-                'permission_callback' => static fn (): bool => current_user_can('manage_options'),
+                'permission_callback' => static fn (): bool => Security::currentUserCanManage(),
                 'args'                => [
                     'email' => [
                         'type'     => 'string',
@@ -75,7 +75,7 @@ final class REST
             [
                 'methods'             => WP_REST_Server::DELETABLE,
                 'callback'            => [self::class, 'handlePrivacyDelete'],
-                'permission_callback' => static fn (): bool => current_user_can('manage_options'),
+                'permission_callback' => static fn (): bool => Security::currentUserCanManage(),
                 'args'                => [
                     'email' => [
                         'type'     => 'string',

--- a/src/Core/RateLimiter.php
+++ b/src/Core/RateLimiter.php
@@ -6,26 +6,57 @@ namespace FP\Resv\Core;
 
 final class RateLimiter
 {
-    public static function allow(string $key, int $limit, int $seconds): bool
+    /**
+     * @return array{allowed: bool, remaining: int, retry_after: int, limit: int}
+     */
+    public static function check(string $key, int $limit, int $seconds): array
     {
-        $key        = 'fp_resv_rl_' . md5($key);
-        $windowData = get_transient($key);
+        $now       = time();
+        $cacheKey  = 'fp_resv_rl_' . md5($key);
+        $window    = get_transient($cacheKey);
 
-        if (!is_array($windowData)) {
-            $windowData = [
-                'count' => 0,
+        if (!is_array($window)) {
+            $window = [];
+        }
+
+        $startedAt = (int) ($window['started_at'] ?? 0);
+        if ($startedAt <= 0 || ($startedAt + $seconds) <= $now) {
+            $startedAt = $now;
+            $window    = [
+                'count'      => 0,
+                'started_at' => $startedAt,
             ];
         }
 
-        $count = (int) ($windowData['count'] ?? 0);
-        if ($count >= $limit) {
-            return false;
+        $count   = (int) ($window['count'] ?? 0);
+        $allowed = $count < $limit;
+
+        if ($allowed) {
+            $count++;
+            $window['count'] = $count;
         }
 
-        $windowData['count'] = $count + 1;
+        $window['started_at'] = $startedAt;
 
-        set_transient($key, $windowData, $seconds);
+        $expiresAt  = $startedAt + $seconds;
+        $retryAfter = max(0, $expiresAt - $now);
+        $remaining  = max(0, $limit - $count);
 
-        return true;
+        $ttl = max(1, $retryAfter === 0 ? $seconds : $retryAfter);
+        set_transient($cacheKey, $window, $ttl);
+
+        return [
+            'allowed'     => $allowed,
+            'remaining'   => $remaining,
+            'retry_after' => $allowed ? 0 : $retryAfter,
+            'limit'       => $limit,
+        ];
+    }
+
+    public static function allow(string $key, int $limit, int $seconds): bool
+    {
+        $result = self::check($key, $limit, $seconds);
+
+        return $result['allowed'];
     }
 }

--- a/src/Core/Security.php
+++ b/src/Core/Security.php
@@ -8,6 +8,7 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 use function add_filter;
+use function apply_filters;
 use function current_user_can;
 use function is_string;
 use function strpos;
@@ -21,7 +22,17 @@ final class Security
 
     public static function currentUserCanManage(): bool
     {
-        return current_user_can('manage_options');
+        return current_user_can(self::managementCapability());
+    }
+
+    public static function managementCapability(): string
+    {
+        $capability = apply_filters('fp_resv_management_capability', 'manage_options');
+        if (!is_string($capability) || $capability === '') {
+            return 'manage_options';
+        }
+
+        return $capability;
     }
 
     public static function enforceNoStoreHeaders(

--- a/src/Core/Validator.php
+++ b/src/Core/Validator.php
@@ -7,11 +7,57 @@ namespace FP\Resv\Core;
 final class Validator
 {
     /**
+     * Recursively sanitize a mixed payload preserving non-string primitives.
+     *
+     * Strings are filtered using `sanitize_text_field()` by default while
+     * multi-line strings fallback to `sanitize_textarea_field()` so line breaks
+     * are preserved. Arrays are traversed recursively and scalars such as
+     * integers, floats, booleans and null values are returned untouched.
+     *
      * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
      */
     public static function sanitize(array $data): array
     {
-        // @todo Implement validation and sanitization.
-        return array_map('sanitize_text_field', $data);
+        $sanitized = [];
+
+        foreach ($data as $key => $value) {
+            $sanitized[$key] = self::sanitizeValue($value);
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private static function sanitizeValue(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            $result = [];
+
+            foreach ($value as $nestedKey => $nestedValue) {
+                $result[$nestedKey] = self::sanitizeValue($nestedValue);
+            }
+
+            return $result;
+        }
+
+        if (is_string($value)) {
+            $hasLineBreaks = str_contains($value, "\n") || str_contains($value, "\r");
+
+            return $hasLineBreaks
+                ? sanitize_textarea_field($value)
+                : sanitize_text_field($value);
+        }
+
+        if (is_scalar($value) || $value === null) {
+            return $value;
+        }
+
+        return sanitize_text_field((string) $value);
     }
 }

--- a/src/Domain/Closures/AdminController.php
+++ b/src/Domain/Closures/AdminController.php
@@ -8,6 +8,7 @@ use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
 use FP\Resv\Core\Plugin;
+use FP\Resv\Core\Security;
 use InvalidArgumentException;
 use function __;
 use function add_action;
@@ -21,11 +22,11 @@ use function wp_create_nonce;
 use function wp_enqueue_script;
 use function wp_enqueue_style;
 use function wp_localize_script;
+use function wp_set_script_translations;
 use function wp_timezone;
 
 final class AdminController
 {
-    private const CAPABILITY = 'manage_options';
     private const PAGE_SLUG = 'fp-resv-closures-app';
 
     private ?string $pageHook = null;
@@ -46,7 +47,7 @@ final class AdminController
             'fp-resv-settings',
             __('Chiusure & orari speciali', 'fp-restaurant-reservations'),
             __('Chiusure', 'fp-restaurant-reservations'),
-            self::CAPABILITY,
+            Security::managementCapability(),
             self::PAGE_SLUG,
             [$this, 'renderPage']
         );
@@ -66,6 +67,10 @@ final class AdminController
         $styleUrl  = Plugin::$url . 'assets/css/admin-closures.css';
 
         wp_enqueue_script($scriptHandle, $scriptUrl, ['wp-api-fetch'], Plugin::VERSION, true);
+
+        if (function_exists('wp_set_script_translations')) {
+            wp_set_script_translations($scriptHandle, 'fp-restaurant-reservations', Plugin::$dir . 'languages');
+        }
 
         wp_enqueue_style($baseHandle, Plugin::$url . 'assets/css/admin-shell.css', [], Plugin::VERSION);
 

--- a/src/Domain/Customers/Model.php
+++ b/src/Domain/Customers/Model.php
@@ -12,6 +12,9 @@ final class Model
     public string $lastName = '';
     public string $name = '';
     public string $phone = '';
+    public string $phoneE164 = '';
+    public string $phoneCountry = '';
+    public string $phoneNational = '';
     public string $lang = '';
     public bool $marketingConsent = false;
     public bool $profilingConsent = false;

--- a/src/Domain/Customers/Repository.php
+++ b/src/Domain/Customers/Repository.php
@@ -39,6 +39,9 @@ final class Repository
         $model->lastName  = (string) ($row['last_name'] ?? '');
         $model->lang    = isset($row['lang']) ? (string) $row['lang'] : '';
         $model->phone   = isset($row['phone']) ? (string) $row['phone'] : '';
+        $model->phoneE164 = isset($row['phone_e164']) ? (string) $row['phone_e164'] : '';
+        $model->phoneCountry = isset($row['phone_country']) ? (string) $row['phone_country'] : '';
+        $model->phoneNational = isset($row['phone_national']) ? (string) $row['phone_national'] : '';
         $model->name    = trim((string) ($row['first_name'] ?? '') . ' ' . (string) ($row['last_name'] ?? ''));
         $model->marketingConsent = ((int) ($row['marketing_consent'] ?? 0)) === 1;
         $model->profilingConsent = ((int) ($row['profiling_consent'] ?? 0)) === 1;
@@ -59,6 +62,9 @@ final class Repository
             'last_name'         => '',
             'email'             => $email,
             'phone'             => '',
+            'phone_e164'        => null,
+            'phone_country'     => null,
+            'phone_national'    => null,
             'lang'              => null,
             'marketing_consent' => 0,
             'profiling_consent' => 0,
@@ -78,6 +84,13 @@ final class Repository
             $payload['consent_version'] = $payload['consent_version'] !== ''
                 ? (string) $payload['consent_version']
                 : null;
+        }
+
+        foreach (['phone_e164', 'phone_country', 'phone_national'] as $key) {
+            if (isset($payload[$key])) {
+                $value = (string) $payload[$key];
+                $payload[$key] = $value !== '' ? $value : null;
+            }
         }
 
         if ($existing !== null) {
@@ -109,6 +122,9 @@ final class Repository
                 'last_name'         => '',
                 'email'             => $placeholderEmail,
                 'phone'             => null,
+                'phone_e164'        => null,
+                'phone_country'     => null,
+                'phone_national'    => null,
                 'lang'              => null,
                 'marketing_consent' => 0,
                 'profiling_consent' => 0,

--- a/src/Domain/Diagnostics/AdminController.php
+++ b/src/Domain/Diagnostics/AdminController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Resv\Domain\Diagnostics;
 
 use FP\Resv\Core\Plugin;
+use FP\Resv\Core\Security;
 use function __;
 use function add_action;
 use function add_submenu_page;
@@ -21,10 +22,10 @@ use function wp_date;
 use function wp_enqueue_script;
 use function wp_enqueue_style;
 use function wp_localize_script;
+use function wp_set_script_translations;
 
 final class AdminController
 {
-    private const CAPABILITY = 'manage_options';
     private const PAGE_SLUG  = 'fp-resv-diagnostics';
 
     private ?string $pageHook = null;
@@ -45,7 +46,7 @@ final class AdminController
             'fp-resv-settings',
             __('Diagnostica', 'fp-restaurant-reservations'),
             __('Diagnostica', 'fp-restaurant-reservations'),
-            self::CAPABILITY,
+            Security::managementCapability(),
             self::PAGE_SLUG,
             [$this, 'renderPage']
         );
@@ -79,6 +80,10 @@ final class AdminController
             Plugin::VERSION,
             true
         );
+
+        if (function_exists('wp_set_script_translations')) {
+            wp_set_script_translations($scriptHandle, 'fp-restaurant-reservations', Plugin::$dir . 'languages');
+        }
 
         $end   = wp_date('Y-m-d');
         $start = wp_date('Y-m-d', strtotime('-13 days'));

--- a/src/Domain/Diagnostics/Logger.php
+++ b/src/Domain/Diagnostics/Logger.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\Resv\Domain\Diagnostics;
+
+use wpdb;
+use function current_time;
+use const ARRAY_A;
+use function is_numeric;
+use function is_string;
+use function wp_json_encode;
+
+final class Logger
+{
+    public function __construct(private readonly wpdb $wpdb)
+    {
+    }
+
+    public function tableName(): string
+    {
+        return $this->wpdb->prefix . 'fp_resv_logs';
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function log(string $channel, string $message, array $context = []): void
+    {
+        $channel = $channel !== '' ? $channel : 'general';
+        $payload = [
+            'channel'        => $channel,
+            'message'        => $message,
+            'context_json'   => $this->encodeContext($context),
+            'reservation_id' => $this->extractNumeric($context, 'reservation_id'),
+            'customer_id'    => $this->extractNumeric($context, 'customer_id'),
+            'created_at'     => current_time('mysql'),
+        ];
+
+        $this->wpdb->insert($this->tableName(), $payload);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function recent(int $limit = 50): array
+    {
+        $limit = max(1, $limit);
+        $sql   = $this->wpdb->prepare('SELECT * FROM ' . $this->tableName() . ' ORDER BY id DESC LIMIT %d', $limit);
+
+        return $this->wpdb->get_results($sql, ARRAY_A) ?: [];
+    }
+
+    private function encodeContext(array $context): ?string
+    {
+        if ($context === []) {
+            return null;
+        }
+
+        $encoded = wp_json_encode($context);
+
+        return is_string($encoded) ? $encoded : null;
+    }
+
+    private function extractNumeric(array $context, string $key): ?int
+    {
+        if (!isset($context[$key])) {
+            return null;
+        }
+
+        $value = $context[$key];
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Domain/Diagnostics/REST.php
+++ b/src/Domain/Diagnostics/REST.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace FP\Resv\Domain\Diagnostics;
 
+use FP\Resv\Core\Security;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 use function __;
 use function add_action;
-use function current_user_can;
 use function register_rest_route;
 use function rest_ensure_response;
 use function sanitize_text_field;
@@ -145,7 +145,7 @@ final class REST
 
     public function checkPermissions(): bool|WP_Error
     {
-        if (!current_user_can('manage_options')) {
+        if (!Security::currentUserCanManage()) {
             return new WP_Error(
                 'fp_resv_forbidden',
                 __('Non hai i permessi per visualizzare questi log.', 'fp-restaurant-reservations'),

--- a/src/Domain/Payments/REST.php
+++ b/src/Domain/Payments/REST.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Resv\Domain\Payments;
 
 use FP\Resv\Core\Logging;
+use FP\Resv\Core\Security;
 use FP\Resv\Domain\Reservations\Repository as ReservationsRepository;
 use RuntimeException;
 use Throwable;
@@ -15,7 +16,6 @@ use WP_REST_Server;
 use function __;
 use function absint;
 use function add_action;
-use function current_user_can;
 use function is_array;
 use function is_string;
 use function register_rest_route;
@@ -213,7 +213,7 @@ final class REST
 
     private function checkAdminPermission(): bool
     {
-        return current_user_can('manage_options');
+        return Security::currentUserCanManage();
     }
 
     private function applyReservationStatus(int $reservationId, string $paymentStatus): ?string

--- a/src/Domain/QA/REST.php
+++ b/src/Domain/QA/REST.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Resv\Domain\QA;
 
 use FP\Resv\Core\Helpers;
+use FP\Resv\Core\Security;
 use FP\Resv\Core\RateLimiter;
 use WP_Error;
 use WP_REST_Request;
@@ -13,7 +14,8 @@ use WP_REST_Server;
 use function __;
 use function absint;
 use function add_action;
-use function current_user_can;
+use function apply_filters;
+use function is_array;
 use function register_rest_route;
 use function rest_ensure_response;
 use function rest_sanitize_boolean;
@@ -58,12 +60,29 @@ final class REST
         $dryRun = rest_sanitize_boolean($request->get_param('dry_run'));
 
         $ip = Helpers::clientIp();
-        if (!RateLimiter::allow('qa_seed:' . $ip, 3, 300)) {
-            return new WP_Error(
-                'fp_resv_rate_limited',
-                __('Hai effettuato troppe richieste di seed. Riprova tra qualche minuto.', 'fp-restaurant-reservations'),
-                ['status' => 429]
+        $rateConfig = $this->resolveRateLimit($request);
+        $limitResult = RateLimiter::check('qa_seed:' . $ip, $rateConfig['limit'], $rateConfig['seconds']);
+        if (!$limitResult['allowed']) {
+            $retryAfter = $limitResult['retry_after'] > 0 ? $limitResult['retry_after'] : $rateConfig['seconds'];
+
+            $response = new WP_REST_Response(
+                [
+                    'code'    => 'fp_resv_rate_limited',
+                    'message' => __('Hai effettuato troppe richieste di seed. Riprova tra qualche minuto.', 'fp-restaurant-reservations'),
+                    'data'    => [
+                        'status'      => 429,
+                        'retry_after' => $retryAfter,
+                    ],
+                ],
+                429
             );
+
+            $response->set_headers([
+                'Retry-After'   => (string) max(1, $retryAfter),
+                'Cache-Control' => 'no-store, no-cache, must-revalidate, max-age=0',
+            ]);
+
+            return $response;
         }
 
         $summary = $this->seeder->seed($days > 0 ? $days : 14, $dryRun);
@@ -76,7 +95,7 @@ final class REST
 
     public function checkPermissions(): bool|WP_Error
     {
-        if (!current_user_can('manage_options')) {
+        if (!Security::currentUserCanManage()) {
             return new WP_Error(
                 'fp_resv_forbidden',
                 __('Non hai i permessi per eseguire il seed QA.', 'fp-restaurant-reservations'),
@@ -85,5 +104,42 @@ final class REST
         }
 
         return true;
+    }
+
+    /**
+     * @return array{limit:int, seconds:int}
+     */
+    private function resolveRateLimit(WP_REST_Request $request): array
+    {
+        $config = apply_filters('fp_resv_rate_limit_qa_seed', [
+            'limit'   => 3,
+            'seconds' => 300,
+        ], $request);
+
+        $limit   = 3;
+        $seconds = 300;
+
+        if (is_array($config)) {
+            if (isset($config['limit'])) {
+                $limit = (int) $config['limit'];
+            }
+
+            if (isset($config['seconds'])) {
+                $seconds = (int) $config['seconds'];
+            }
+        }
+
+        if ($limit < 1) {
+            $limit = 3;
+        }
+
+        if ($seconds < 1) {
+            $seconds = 300;
+        }
+
+        return [
+            'limit'   => $limit,
+            'seconds' => $seconds,
+        ];
     }
 }

--- a/src/Domain/Reports/AdminController.php
+++ b/src/Domain/Reports/AdminController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Resv\Domain\Reports;
 
 use FP\Resv\Core\Plugin;
+use FP\Resv\Core\Security;
 use function __;
 use function add_action;
 use function add_submenu_page;
@@ -19,10 +20,10 @@ use function wp_date;
 use function wp_enqueue_script;
 use function wp_enqueue_style;
 use function wp_localize_script;
+use function wp_set_script_translations;
 
 final class AdminController
 {
-    private const CAPABILITY = 'manage_options';
     private const PAGE_SLUG  = 'fp-resv-analytics';
 
     private ?string $pageHook = null;
@@ -43,7 +44,7 @@ final class AdminController
             'fp-resv-settings',
             __('Report & Analytics', 'fp-restaurant-reservations'),
             __('Report & Analytics', 'fp-restaurant-reservations'),
-            self::CAPABILITY,
+            Security::managementCapability(),
             self::PAGE_SLUG,
             [$this, 'renderPage']
         );
@@ -78,6 +79,10 @@ final class AdminController
         );
 
         wp_enqueue_script($scriptHandle, $scriptUrl, ['wp-api-fetch', $chartHandle], Plugin::VERSION, true);
+
+        if (function_exists('wp_set_script_translations')) {
+            wp_set_script_translations($scriptHandle, 'fp-restaurant-reservations', Plugin::$dir . 'languages');
+        }
 
         $end   = wp_date('Y-m-d');
         $start = wp_date('Y-m-d', strtotime('-29 days'));

--- a/src/Domain/Reports/REST.php
+++ b/src/Domain/Reports/REST.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FP\Resv\Domain\Reports;
 
+use FP\Resv\Core\Security;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -11,7 +12,6 @@ use WP_REST_Server;
 use function __;
 use function add_action;
 use function base64_encode;
-use function current_user_can;
 use function register_rest_route;
 use function rest_ensure_response;
 use function sanitize_text_field;
@@ -197,7 +197,7 @@ final class REST
 
     public function checkPermissions(): bool|WP_Error
     {
-        if (!current_user_can('manage_options')) {
+        if (!Security::currentUserCanManage()) {
             return new WP_Error(
                 'fp_resv_forbidden',
                 __('Non hai i permessi per visualizzare questi report.', 'fp-restaurant-reservations'),

--- a/src/Domain/Reservations/AdminController.php
+++ b/src/Domain/Reservations/AdminController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Resv\Domain\Reservations;
 
 use FP\Resv\Core\Plugin;
+use FP\Resv\Core\Security;
 use function __;
 use function add_action;
 use function add_submenu_page;
@@ -18,10 +19,10 @@ use function wp_create_nonce;
 use function wp_enqueue_script;
 use function wp_enqueue_style;
 use function wp_localize_script;
+use function wp_set_script_translations;
 
 final class AdminController
 {
-    private const CAPABILITY = 'manage_options';
     private const PAGE_SLUG = 'fp-resv-agenda';
 
     private ?string $pageHook = null;
@@ -38,7 +39,7 @@ final class AdminController
             'fp-resv-settings',
             __('Agenda prenotazioni', 'fp-restaurant-reservations'),
             __('Agenda', 'fp-restaurant-reservations'),
-            self::CAPABILITY,
+            Security::managementCapability(),
             self::PAGE_SLUG,
             [$this, 'renderPage']
         );
@@ -58,6 +59,10 @@ final class AdminController
         $styleUrl  = Plugin::$url . 'assets/css/admin-agenda.css';
 
         wp_enqueue_script($scriptHandle, $scriptUrl, ['wp-api-fetch'], Plugin::VERSION, true);
+
+        if (function_exists('wp_set_script_translations')) {
+            wp_set_script_translations($scriptHandle, 'fp-restaurant-reservations', Plugin::$dir . 'languages');
+        }
 
         wp_enqueue_style($baseHandle, Plugin::$url . 'assets/css/admin-shell.css', [], Plugin::VERSION);
 

--- a/src/Domain/Reservations/AdminREST.php
+++ b/src/Domain/Reservations/AdminREST.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Resv\Domain\Reservations;
 
 use DateInterval;
+use FP\Resv\Core\Security;
 use DateTimeImmutable;
 use FP\Resv\Domain\Calendar\GoogleCalendarService;
 use InvalidArgumentException;
@@ -23,7 +24,6 @@ use function array_values;
 use function add_action;
 use function do_action;
 use function current_time;
-use function current_user_can;
 use function gmdate;
 use function in_array;
 use function is_array;
@@ -399,7 +399,7 @@ final class AdminREST
 
     private function checkPermissions(): bool
     {
-        return current_user_can('manage_options');
+        return Security::currentUserCanManage();
     }
 
     private function sanitizeDate(mixed $value): ?string
@@ -475,6 +475,12 @@ final class AdminREST
             'utm_source' => $request->get_param('utm_source') ?? '',
             'utm_medium' => $request->get_param('utm_medium') ?? '',
             'utm_campaign' => $request->get_param('utm_campaign') ?? '',
+            'utm_content' => $request->get_param('utm_content') ?? '',
+            'utm_term' => $request->get_param('utm_term') ?? '',
+            'gclid' => $request->get_param('gclid') ?? '',
+            'fbclid' => $request->get_param('fbclid') ?? '',
+            'msclkid' => $request->get_param('msclkid') ?? '',
+            'ttclid' => $request->get_param('ttclid') ?? '',
             'status'     => $request->get_param('status') ?? null,
             'room_id'    => $request->get_param('room_id') ?? null,
             'table_id'   => $request->get_param('table_id') ?? null,

--- a/src/Domain/Reservations/AvailabilityCache.php
+++ b/src/Domain/Reservations/AvailabilityCache.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\Resv\Domain\Reservations;
+
+use function add_action;
+use function array_values;
+use function delete_option;
+use function delete_transient;
+use function get_option;
+use function in_array;
+use function is_array;
+use function set_transient;
+use function update_option;
+
+final class AvailabilityCache
+{
+    private const OPTION_KEY = 'fp_resv_availability_cache_keys';
+
+    /**
+     * @param array<string, mixed> $value
+     */
+    public static function remember(string $key, array $value, int $expiration): void
+    {
+        set_transient($key, $value, $expiration);
+
+        $keys = get_option(self::OPTION_KEY, []);
+        if (!is_array($keys)) {
+            $keys = [];
+        }
+
+        if (!in_array($key, $keys, true)) {
+            $keys[] = $key;
+            update_option(self::OPTION_KEY, array_values($keys), false);
+        }
+    }
+
+    public static function flush(): void
+    {
+        $keys = get_option(self::OPTION_KEY, []);
+        if (!is_array($keys)) {
+            $keys = [];
+        }
+
+        foreach ($keys as $key) {
+            delete_transient((string) $key);
+        }
+
+        delete_option(self::OPTION_KEY);
+    }
+
+    public static function bootstrap(): void
+    {
+        $callbacks = [self::class, 'flush'];
+
+        add_action('fp_resv_reservation_created', $callbacks, 10, 0);
+        add_action('fp_resv_reservation_updated', $callbacks, 10, 0);
+        add_action('fp_resv_reservation_moved', $callbacks, 10, 0);
+        add_action('fp_resv_reservation_status_changed', $callbacks, 10, 0);
+        add_action('fp_resv_event_booked', $callbacks, 10, 0);
+        add_action('fp_resv_closure_saved', $callbacks, 10, 0);
+        add_action('fp_resv_closure_deleted', $callbacks, 10, 0);
+    }
+}

--- a/src/Domain/Reservations/CLI.php
+++ b/src/Domain/Reservations/CLI.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\Resv\Domain\Reservations;
+
+final class CLI
+{
+    public function register(): void
+    {
+        if (!defined('WP_CLI') || !\WP_CLI) {
+            return;
+        }
+
+        \WP_CLI::add_command('fp-resv reservations revoke-tokens', [$this, 'handleRevoke']);
+    }
+
+    public function handleRevoke(): void
+    {
+        ManageTokens::revokeAll();
+        \WP_CLI::success('Token di gestione prenotazioni revocati.');
+    }
+}

--- a/src/Domain/Reservations/ManageTokens.php
+++ b/src/Domain/Reservations/ManageTokens.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\Resv\Domain\Reservations;
+
+use function absint;
+use function apply_filters;
+use function delete_option;
+use function explode;
+use function get_option;
+use function hash_equals;
+use function hash_hmac;
+use function is_array;
+use function sanitize_text_field;
+use function strtolower;
+use function time;
+use function trim;
+use function update_option;
+use function wp_salt;
+use const MINUTE_IN_SECONDS;
+use const WEEK_IN_SECONDS;
+
+final class ManageTokens
+{
+    private const OPTION_KEY = 'fp_resv_manage_tokens';
+
+    public static function issue(int $reservationId, string $email): string
+    {
+        $normalized = strtolower(trim($email));
+        $ttl = (int) apply_filters('fp_resv_manage_token_ttl', WEEK_IN_SECONDS, $reservationId, $normalized);
+        if ($ttl < MINUTE_IN_SECONDS) {
+            $ttl = MINUTE_IN_SECONDS;
+        }
+
+        $expiresAt = time() + $ttl;
+        $signature = hash_hmac('sha256', self::payload($reservationId, $normalized, $expiresAt), wp_salt('fp_resv_manage'));
+        $token = $expiresAt . '.' . $signature;
+
+        self::store($token, $reservationId, $expiresAt);
+        self::prune();
+
+        return $token;
+    }
+
+    public static function verify(int $reservationId, string $email, string $token): bool
+    {
+        $token = sanitize_text_field($token);
+        if ($token === '') {
+            return false;
+        }
+
+        $parts = explode('.', $token, 2);
+        if (count($parts) !== 2) {
+            return false;
+        }
+
+        $expiresAt = absint($parts[0]);
+        if ($expiresAt < time()) {
+            return false;
+        }
+
+        $normalized = strtolower(trim($email));
+        $expected = hash_hmac('sha256', self::payload($reservationId, $normalized, $expiresAt), wp_salt('fp_resv_manage'));
+
+        if (!hash_equals($expected, $parts[1])) {
+            return false;
+        }
+
+        $store = self::load();
+        $meta = $store[$token] ?? null;
+        if (!is_array($meta)) {
+            return false;
+        }
+
+        if ((int) ($meta['reservation_id'] ?? 0) !== $reservationId) {
+            return false;
+        }
+
+        if ((int) ($meta['expires_at'] ?? 0) < time()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static function revokeAll(): void
+    {
+        delete_option(self::OPTION_KEY);
+    }
+
+    private static function payload(int $reservationId, string $email, int $expiresAt): string
+    {
+        return $reservationId . '|' . $email . '|' . $expiresAt;
+    }
+
+    private static function store(string $token, int $reservationId, int $expiresAt): void
+    {
+        $store = self::load();
+        $store[$token] = [
+            'reservation_id' => $reservationId,
+            'expires_at'     => $expiresAt,
+        ];
+
+        update_option(self::OPTION_KEY, $store, false);
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     */
+    private static function load(): array
+    {
+        $stored = get_option(self::OPTION_KEY, []);
+        if (!is_array($stored)) {
+            return [];
+        }
+
+        return $stored;
+    }
+
+    private static function prune(): void
+    {
+        $store = self::load();
+        if ($store === []) {
+            return;
+        }
+
+        $now = time();
+        $changed = false;
+
+        foreach ($store as $token => $meta) {
+            if (!is_array($meta) || (int) ($meta['expires_at'] ?? 0) < $now) {
+                unset($store[$token]);
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            if ($store === []) {
+                delete_option(self::OPTION_KEY);
+            } else {
+                update_option(self::OPTION_KEY, $store, false);
+            }
+        }
+    }
+}

--- a/src/Domain/Reservations/REST.php
+++ b/src/Domain/Reservations/REST.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace FP\Resv\Domain\Reservations;
 
+use FP\Resv\Core\DataLayer;
 use FP\Resv\Core\Helpers;
 use FP\Resv\Core\RateLimiter;
+use FP\Resv\Domain\Reservations\AvailabilityCache;
 use FP\Resv\Domain\Reservations\Service;
 use InvalidArgumentException;
 use RuntimeException;
@@ -22,12 +24,17 @@ use function defined;
 use function get_transient;
 use function in_array;
 use function is_array;
+use function is_bool;
+use function is_numeric;
 use function is_string;
+use function is_email;
 use function preg_match;
 use function register_rest_route;
 use function rest_ensure_response;
+use function max;
+use function sanitize_email;
 use function sanitize_text_field;
-use function set_transient;
+use function sanitize_textarea_field;
 use function strtolower;
 use function wp_json_encode;
 use function wp_rand;
@@ -79,6 +86,11 @@ final class REST
                         'type'              => 'integer',
                         'sanitize_callback' => static fn ($value): int => absint($value),
                     ],
+                    'location' => [
+                        'required'          => false,
+                        'type'              => 'string',
+                        'sanitize_callback' => static fn ($value): string => sanitize_text_field((string) $value),
+                    ],
                     'event_id' => [
                         'required'          => false,
                         'type'              => 'integer',
@@ -95,26 +107,30 @@ final class REST
                 'methods'             => WP_REST_Server::CREATABLE,
                 'callback'            => [$this, 'handleCreateReservation'],
                 'permission_callback' => '__return_true',
+                'args'                => $this->reservationArgsSchema(),
             ]
         );
     }
 
     public function handleAvailability(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
+        $rateLimit = $this->resolveRateLimit('fp_resv_rate_limit_availability', 30, 60, $request);
         $ip = Helpers::clientIp();
-        if (!RateLimiter::allow('availability:' . $ip, 30, 60)) {
+        $limitResult = RateLimiter::check('availability:' . $ip, $rateLimit['limit'], $rateLimit['seconds']);
+        if (!$limitResult['allowed']) {
+            $retryAfter = $limitResult['retry_after'] > 0 ? $limitResult['retry_after'] : $rateLimit['seconds'];
             $payload = [
                 'code'    => 'fp_resv_availability_rate_limited',
                 'message' => __('Hai effettuato troppe richieste di disponibilità. Attendi qualche secondo e riprova.', 'fp-restaurant-reservations'),
                 'data'    => [
                     'status'      => 429,
-                    'retry_after' => 20,
+                    'retry_after' => $retryAfter,
                 ],
             ];
 
             $response = new WP_REST_Response($payload, 429);
             $response->set_headers([
-                'Retry-After'   => '20',
+                'Retry-After'   => (string) max(1, $retryAfter),
                 'Cache-Control' => 'no-store, no-cache, must-revalidate, max-age=0',
             ]);
 
@@ -136,6 +152,11 @@ final class REST
             $criteria['room'] = absint($room);
         }
 
+        $location = $request->get_param('location');
+        if (is_string($location) && $location !== '') {
+            $criteria['location'] = sanitize_text_field($location);
+        }
+
         $event = $request->get_param('event_id');
         if ($event !== null) {
             $criteria['event_id'] = absint($event);
@@ -146,6 +167,7 @@ final class REST
             'party'   => $criteria['party'],
             'meal'    => $criteria['meal'] ?? '',
             'room'    => $criteria['room'] ?? '',
+            'location'=> $criteria['location'] ?? '',
             'event'   => $criteria['event_id'] ?? '',
         ];
 
@@ -188,7 +210,7 @@ final class REST
             );
         }
 
-        set_transient($cacheKey, $result, wp_rand(30, 60));
+        AvailabilityCache::remember($cacheKey, $result, wp_rand(30, 60));
 
         $response = rest_ensure_response($result);
         if ($response instanceof WP_REST_Response) {
@@ -216,13 +238,13 @@ final class REST
             );
         }
 
+        $rateLimit = $this->resolveRateLimit('fp_resv_rate_limit_reservations', 5, 300, $request);
         $ip = Helpers::clientIp();
-        if (!RateLimiter::allow('reservation:' . $ip, 5, 300)) {
-            return new WP_Error(
-                'fp_resv_rate_limited',
-                __('Hai effettuato troppe richieste. Attendi qualche minuto e riprova.', 'fp-restaurant-reservations'),
-                ['status' => 429]
-            );
+        $limitResult = RateLimiter::check('reservation:' . $ip, $rateLimit['limit'], $rateLimit['seconds']);
+        if (!$limitResult['allowed']) {
+            $retryAfter = $limitResult['retry_after'] > 0 ? $limitResult['retry_after'] : $rateLimit['seconds'];
+
+            return $this->buildReservationRateLimitResponse($retryAfter);
         }
 
         $honeypot = $this->param($request, ['fp_resv_hp']);
@@ -255,25 +277,55 @@ final class REST
             'date'        => $this->param($request, ['date', 'fp_resv_date']) ?? '',
             'time'        => $this->param($request, ['time', 'fp_resv_time']) ?? '',
             'party'       => (int) ($this->param($request, ['party', 'fp_resv_party']) ?? 0),
+            'meal'        => $this->param($request, ['meal', 'fp_resv_meal']) ?? '',
             'first_name'  => $this->param($request, ['first_name', 'fp_resv_first_name']) ?? '',
             'last_name'   => $this->param($request, ['last_name', 'fp_resv_last_name']) ?? '',
             'email'       => $this->param($request, ['email', 'fp_resv_email']) ?? '',
             'phone'       => $this->param($request, ['phone', 'fp_resv_phone']) ?? '',
+            'phone_e164'  => $this->param($request, ['phone_e164', 'fp_resv_phone_e164']) ?? '',
+            'phone_country' => $this->param($request, ['phone_country', 'fp_resv_phone_cc']) ?? '',
+            'phone_national'=> $this->param($request, ['phone_national', 'fp_resv_phone_local']) ?? '',
             'notes'       => $this->param($request, ['notes', 'fp_resv_notes']) ?? '',
             'allergies'   => $this->param($request, ['allergies', 'fp_resv_allergies']) ?? '',
             'language'    => $this->param($request, ['language', 'fp_resv_language']) ?? '',
             'locale'      => $this->param($request, ['locale', 'fp_resv_locale']) ?? '',
             'location'    => $this->param($request, ['location', 'fp_resv_location']) ?? '',
             'currency'    => $this->param($request, ['currency', 'fp_resv_currency']) ?? '',
+            'status'      => $this->param($request, ['status', 'fp_resv_status']),
+            'room_id'     => $this->param($request, ['room_id', 'fp_resv_room_id', 'fp_resv_room']),
+            'table_id'    => $this->param($request, ['table_id', 'fp_resv_table_id', 'fp_resv_table']),
             'utm_source'  => $this->param($request, ['utm_source']) ?? '',
             'utm_medium'  => $this->param($request, ['utm_medium']) ?? '',
             'utm_campaign'=> $this->param($request, ['utm_campaign']) ?? '',
+            'utm_content' => $this->param($request, ['utm_content']) ?? '',
+            'utm_term'    => $this->param($request, ['utm_term']) ?? '',
+            'gclid'       => $this->param($request, ['gclid']) ?? '',
+            'fbclid'      => $this->param($request, ['fbclid']) ?? '',
+            'msclkid'     => $this->param($request, ['msclkid']) ?? '',
+            'ttclid'      => $this->param($request, ['ttclid']) ?? '',
             'marketing_consent' => $this->param($request, ['marketing_consent', 'fp_resv_marketing_consent']) ?? '',
             'profiling_consent' => $this->param($request, ['profiling_consent', 'fp_resv_profiling_consent']) ?? '',
             'policy_version'    => $this->param($request, ['policy_version', 'fp_resv_policy_version']) ?? '',
             'consent_timestamp' => $this->param($request, ['consent_ts', 'fp_resv_consent_ts']) ?? '',
             'value'       => $this->param($request, ['value', 'fp_resv_value']),
+            'price_per_person' => $this->param($request, ['price_per_person', 'fp_resv_price_per_person']),
         ];
+
+        $emailForLimit = sanitize_email((string) $payload['email']);
+        if ($emailForLimit !== '') {
+            $emailLimit = $this->resolveRateLimit('fp_resv_rate_limit_reservations_email', 5, 300, $request);
+            $emailResult = RateLimiter::check(
+                'reservation-email:' . md5(strtolower($emailForLimit)),
+                $emailLimit['limit'],
+                $emailLimit['seconds']
+            );
+
+            if (!$emailResult['allowed']) {
+                $retryAfter = $emailResult['retry_after'] > 0 ? $emailResult['retry_after'] : $emailLimit['seconds'];
+
+                return $this->buildReservationRateLimitResponse($retryAfter);
+            }
+        }
 
         try {
             $result = $this->service->create($payload);
@@ -309,6 +361,526 @@ final class REST
         if ($response instanceof WP_REST_Response) {
             $response->set_status(201);
         }
+
+        return $response;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function reservationArgsSchema(): array
+    {
+        $text = static fn ($value): string => sanitize_text_field((string) $value);
+        $textarea = static fn ($value): string => sanitize_textarea_field((string) $value);
+        $email = static fn ($value): string => sanitize_email((string) $value);
+
+        $dateValidator = static function ($value): bool {
+            if ($value === null || $value === '') {
+                return true;
+            }
+
+            if (!is_string($value)) {
+                return false;
+            }
+
+            return preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) === 1;
+        };
+
+        $timeValidator = static function ($value): bool {
+            if ($value === null || $value === '') {
+                return true;
+            }
+
+            if (!is_string($value)) {
+                return false;
+            }
+
+            return preg_match('/^\d{2}:\d{2}$/', $value) === 1;
+        };
+
+        $emailValidator = static function ($value): bool {
+            if ($value === null || $value === '') {
+                return true;
+            }
+
+            if (!is_string($value)) {
+                return false;
+            }
+
+            return is_email($value) !== false;
+        };
+
+        $booleanLike = static function ($value): bool {
+            if ($value === null || $value === '') {
+                return true;
+            }
+
+            if (is_bool($value)) {
+                return true;
+            }
+
+            if (!is_string($value)) {
+                return false;
+            }
+
+            return in_array(strtolower($value), ['1', '0', 'true', 'false', 'yes', 'no', 'on', 'off'], true);
+        };
+
+        $positiveInt = static fn ($value): int => max(0, absint($value));
+
+        $partyValidator = static function ($value): bool {
+            if ($value === null || $value === '') {
+                return true;
+            }
+
+            return absint($value) > 0;
+        };
+
+        $consentValidator = static function ($value): bool {
+            if ($value === null || $value === '') {
+                return true;
+            }
+
+            if (!is_string($value)) {
+                return false;
+            }
+
+            return in_array(strtolower($value), ['1', 'true', 'yes', 'on'], true);
+        };
+
+        $decimalValidator = static function ($value): bool {
+            if ($value === null || $value === '') {
+                return true;
+            }
+
+            if (!is_string($value) && !is_numeric($value)) {
+                return false;
+            }
+
+            $stringValue = (string) $value;
+
+            return preg_match('/^-?\d+(?:[\.,]\d+)?$/', $stringValue) === 1;
+        };
+
+        return [
+            'fp_resv_nonce' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            '_wpnonce' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_hp' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'date' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $dateValidator,
+            ],
+            'fp_resv_date' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $dateValidator,
+            ],
+            'time' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $timeValidator,
+            ],
+            'fp_resv_time' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $timeValidator,
+            ],
+            'party' => [
+                'type'              => 'integer',
+                'required'          => false,
+                'sanitize_callback' => $positiveInt,
+                'validate_callback' => $partyValidator,
+            ],
+            'fp_resv_party' => [
+                'type'              => 'integer',
+                'required'          => false,
+                'sanitize_callback' => $positiveInt,
+                'validate_callback' => $partyValidator,
+            ],
+            'meal' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_meal' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'first_name' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_first_name' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'last_name' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_last_name' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'email' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $email,
+                'validate_callback' => $emailValidator,
+            ],
+            'fp_resv_email' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $email,
+                'validate_callback' => $emailValidator,
+            ],
+            'phone' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'phone_e164' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'phone_country' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'phone_national' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_phone' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_phone_e164' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_phone_cc' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_phone_local' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'notes' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $textarea,
+            ],
+            'fp_resv_notes' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $textarea,
+            ],
+            'allergies' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $textarea,
+            ],
+            'fp_resv_allergies' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $textarea,
+            ],
+            'language' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_language' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'locale' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_locale' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'location' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_location' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'currency' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_currency' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'status' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_status' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'room_id' => [
+                'type'              => 'integer',
+                'required'          => false,
+                'sanitize_callback' => $positiveInt,
+            ],
+            'fp_resv_room_id' => [
+                'type'              => 'integer',
+                'required'          => false,
+                'sanitize_callback' => $positiveInt,
+            ],
+            'fp_resv_room' => [
+                'type'              => 'integer',
+                'required'          => false,
+                'sanitize_callback' => $positiveInt,
+            ],
+            'table_id' => [
+                'type'              => 'integer',
+                'required'          => false,
+                'sanitize_callback' => $positiveInt,
+            ],
+            'fp_resv_table_id' => [
+                'type'              => 'integer',
+                'required'          => false,
+                'sanitize_callback' => $positiveInt,
+            ],
+            'fp_resv_table' => [
+                'type'              => 'integer',
+                'required'          => false,
+                'sanitize_callback' => $positiveInt,
+            ],
+            'utm_source' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'utm_medium' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'utm_campaign' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'utm_content' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'utm_term' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'gclid' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fbclid' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'msclkid' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'ttclid' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'marketing_consent' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $booleanLike,
+            ],
+            'fp_resv_marketing_consent' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $booleanLike,
+            ],
+            'profiling_consent' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $booleanLike,
+            ],
+            'fp_resv_profiling_consent' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $booleanLike,
+            ],
+            'policy_version' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_policy_version' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'consent_ts' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'fp_resv_consent_ts' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+            ],
+            'consent' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $consentValidator,
+            ],
+            'fp_resv_consent' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $consentValidator,
+            ],
+            'value' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $decimalValidator,
+            ],
+            'fp_resv_value' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $decimalValidator,
+            ],
+            'price_per_person' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $decimalValidator,
+            ],
+            'fp_resv_price_per_person' => [
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => $text,
+                'validate_callback' => $decimalValidator,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{limit: int, seconds: int}
+     */
+    private function resolveRateLimit(string $filter, int $defaultLimit, int $defaultSeconds, WP_REST_Request $request): array
+    {
+        $config = apply_filters($filter, [
+            'limit'   => $defaultLimit,
+            'seconds' => $defaultSeconds,
+        ], $request);
+
+        $limit = $defaultLimit;
+        $seconds = $defaultSeconds;
+
+        if (is_array($config)) {
+            if (isset($config['limit'])) {
+                $limit = (int) $config['limit'];
+            }
+
+            if (isset($config['seconds'])) {
+                $seconds = (int) $config['seconds'];
+            }
+        } elseif (is_numeric($config)) {
+            $limit = (int) $config;
+        }
+
+        if ($limit < 1) {
+            $limit = $defaultLimit;
+        }
+
+        if ($seconds < 1) {
+            $seconds = $defaultSeconds;
+        }
+
+        return [
+            'limit'   => $limit,
+            'seconds' => $seconds,
+        ];
+    }
+
+    private function buildReservationRateLimitResponse(int $retryAfter): WP_REST_Response
+    {
+        $retryAfter = max(1, $retryAfter);
+
+        $payload = [
+            'code'    => 'fp_resv_rate_limited',
+            'message' => __('Hai effettuato troppe richieste. Attendi qualche minuto e riprova.', 'fp-restaurant-reservations'),
+            'data'    => [
+                'status'      => 429,
+                'retry_after' => $retryAfter,
+            ],
+        ];
+
+        $response = new WP_REST_Response($payload, 429);
+        $response->set_headers([
+            'Retry-After'   => (string) $retryAfter,
+            'Cache-Control' => 'no-store, no-cache, must-revalidate, max-age=0',
+        ]);
 
         return $response;
     }

--- a/src/Domain/Settings/AdminPages.php
+++ b/src/Domain/Settings/AdminPages.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Resv\Domain\Settings;
 
 use FP\Resv\Core\Plugin;
+use FP\Resv\Core\Security;
 use FP\Resv\Core\ServiceContainer;
 use function __;
 use function add_action;
@@ -15,7 +16,6 @@ use function add_settings_field;
 use function add_settings_section;
 use function add_submenu_page;
 use function array_key_first;
-use function current_user_can;
 use function admin_url;
 use function check_admin_referer;
 use function do_settings_sections;
@@ -68,7 +68,6 @@ use const INPUT_GET;
 
 final class AdminPages
 {
-    private const CAPABILITY = 'manage_options';
     private const DEFAULT_PHONE_PREFIX_MAP = ['+39' => 'IT'];
 
     /**
@@ -79,6 +78,11 @@ final class AdminPages
     public function __construct()
     {
         $this->pages = $this->definePages();
+    }
+
+    private function capability(): string
+    {
+        return Security::managementCapability();
     }
 
     public function register(): void
@@ -152,7 +156,7 @@ final class AdminPages
 
     public function handleStyleReset(): void
     {
-        if (!current_user_can(self::CAPABILITY)) {
+        if (!Security::currentUserCanManage()) {
             wp_safe_redirect(admin_url());
             exit;
         }
@@ -198,7 +202,7 @@ final class AdminPages
         add_menu_page(
             (string) $firstPage['page_title'],
             __('FP Reservations', 'fp-restaurant-reservations'),
-            self::CAPABILITY,
+            $this->capability(),
             $firstPage['slug'],
             function () use ($firstKey): void {
                 $this->renderSettingsPage($firstKey);
@@ -212,7 +216,7 @@ final class AdminPages
                 $firstPage['slug'],
                 (string) $page['page_title'],
                 (string) $page['menu_title'],
-                self::CAPABILITY,
+                $this->capability(),
                 $page['slug'],
                 function () use ($pageKey): void {
                     $this->renderSettingsPage($pageKey);
@@ -377,7 +381,7 @@ final class AdminPages
 
     private function renderSettingsPage(string $pageKey): void
     {
-        if (!current_user_can(self::CAPABILITY)) {
+        if (!Security::currentUserCanManage()) {
             return;
         }
 

--- a/src/Domain/Tables/AdminController.php
+++ b/src/Domain/Tables/AdminController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Resv\Domain\Tables;
 
 use FP\Resv\Core\Plugin;
+use FP\Resv\Core\Security;
 use function __;
 use function add_action;
 use function add_submenu_page;
@@ -17,10 +18,10 @@ use function wp_create_nonce;
 use function wp_enqueue_script;
 use function wp_enqueue_style;
 use function wp_localize_script;
+use function wp_set_script_translations;
 
 final class AdminController
 {
-    private const CAPABILITY = 'manage_options';
     private const PAGE_SLUG = 'fp-resv-layout';
 
     private ?string $pageHook = null;
@@ -41,7 +42,7 @@ final class AdminController
             'fp-resv-settings',
             __('Sale & Tavoli', 'fp-restaurant-reservations'),
             __('Sale & Tavoli', 'fp-restaurant-reservations'),
-            self::CAPABILITY,
+            Security::managementCapability(),
             self::PAGE_SLUG,
             [$this, 'renderPage']
         );
@@ -61,6 +62,10 @@ final class AdminController
         $styleUrl  = Plugin::$url . 'assets/css/admin-tables.css';
 
         wp_enqueue_script($scriptHandle, $scriptUrl, ['wp-api-fetch'], Plugin::VERSION, true);
+
+        if (function_exists('wp_set_script_translations')) {
+            wp_set_script_translations($scriptHandle, 'fp-restaurant-reservations', Plugin::$dir . 'languages');
+        }
 
         wp_enqueue_style($baseHandle, Plugin::$url . 'assets/css/admin-shell.css', [], Plugin::VERSION);
 

--- a/src/Domain/Tables/LayoutService.php
+++ b/src/Domain/Tables/LayoutService.php
@@ -6,6 +6,7 @@ namespace FP\Resv\Domain\Tables;
 
 use InvalidArgumentException;
 use RuntimeException;
+use function __;
 use function array_map;
 use function array_unique;
 use function array_values;
@@ -79,7 +80,7 @@ final class LayoutService
 
         $room = $this->repository->findRoom($roomId);
         if ($room === null) {
-            throw new RuntimeException('Room could not be loaded after save.');
+            throw new RuntimeException(__('Impossibile caricare la sala dopo il salvataggio.', 'fp-restaurant-reservations'));
         }
 
         return $this->roomToArray($this->hydrateRoom($room));
@@ -111,7 +112,7 @@ final class LayoutService
 
         $table = $this->repository->findTable($tableId);
         if ($table === null) {
-            throw new RuntimeException('Table could not be loaded after save.');
+            throw new RuntimeException(__('Impossibile caricare il tavolo dopo il salvataggio.', 'fp-restaurant-reservations'));
         }
 
         return $this->tableToArray($this->hydrateTable($table));
@@ -149,7 +150,7 @@ final class LayoutService
     public function mergeTables(array $tableIds, ?string $groupCode = null): array
     {
         if (count($tableIds) < 2) {
-            throw new InvalidArgumentException('At least two tables are required to create a merge group.');
+            throw new InvalidArgumentException(__('Sono necessari almeno due tavoli per creare un gruppo combinato.', 'fp-restaurant-reservations'));
         }
 
         $tables = [];
@@ -157,7 +158,7 @@ final class LayoutService
         foreach ($tableIds as $tableId) {
             $table = $this->repository->findTable((int) $tableId);
             if ($table === null) {
-                throw new InvalidArgumentException(sprintf('Table %d not found.', (int) $tableId));
+                throw new InvalidArgumentException(sprintf(__('Tavolo %d non trovato.', 'fp-restaurant-reservations'), (int) $tableId));
             }
 
             if ($roomId === null) {
@@ -165,7 +166,7 @@ final class LayoutService
             }
 
             if ((int) $table['room_id'] !== $roomId) {
-                throw new InvalidArgumentException('All tables in a merge group must belong to the same room.');
+                throw new InvalidArgumentException(__('Tutti i tavoli di un gruppo devono appartenere alla stessa sala.', 'fp-restaurant-reservations'));
             }
 
             $tables[] = $this->hydrateTable($table);
@@ -359,12 +360,12 @@ final class LayoutService
     {
         $name = isset($data['name']) ? trim((string) $data['name']) : '';
         if ($name === '') {
-            throw new InvalidArgumentException('Room name is required.');
+            throw new InvalidArgumentException(__('Il nome della sala è obbligatorio.', 'fp-restaurant-reservations'));
         }
 
         $color = isset($data['color']) ? trim((string) $data['color']) : '';
         if ($color !== '' && preg_match('/^#?[0-9a-fA-F]{6}$/', $color) !== 1) {
-            throw new InvalidArgumentException('Room color must be a valid hex value.');
+            throw new InvalidArgumentException(__('Il colore della sala deve essere un valore esadecimale valido.', 'fp-restaurant-reservations'));
         }
 
         if ($color !== '' && $color[0] !== '#') {
@@ -390,16 +391,16 @@ final class LayoutService
     {
         $code = isset($data['code']) ? trim((string) $data['code']) : '';
         if ($code === '') {
-            throw new InvalidArgumentException('Table code is required.');
+            throw new InvalidArgumentException(__('Il codice del tavolo è obbligatorio.', 'fp-restaurant-reservations'));
         }
 
         if (!isset($data['room_id'])) {
-            throw new InvalidArgumentException('Table room_id is required.');
+            throw new InvalidArgumentException(__('Il campo room_id del tavolo è obbligatorio.', 'fp-restaurant-reservations'));
         }
 
         $roomId = (int) $data['room_id'];
         if ($roomId <= 0) {
-            throw new InvalidArgumentException('Table room_id must be a positive integer.');
+            throw new InvalidArgumentException(__('Il campo room_id del tavolo deve essere un intero positivo.', 'fp-restaurant-reservations'));
         }
 
         $status = isset($data['status']) ? strtolower(trim((string) $data['status'])) : 'available';
@@ -440,14 +441,14 @@ final class LayoutService
     private function assertRoomExists(int $roomId): void
     {
         if ($roomId <= 0 || $this->repository->findRoom($roomId) === null) {
-            throw new InvalidArgumentException(sprintf('Room %d does not exist.', $roomId));
+            throw new InvalidArgumentException(sprintf(__('La sala %d non esiste.', 'fp-restaurant-reservations'), $roomId));
         }
     }
 
     private function assertTableExists(int $tableId): void
     {
         if ($tableId <= 0 || $this->repository->findTable($tableId) === null) {
-            throw new InvalidArgumentException(sprintf('Table %d does not exist.', $tableId));
+            throw new InvalidArgumentException(sprintf(__('Il tavolo %d non esiste.', 'fp-restaurant-reservations'), $tableId));
         }
     }
 
@@ -459,7 +460,7 @@ final class LayoutService
         }
 
         if (preg_match('/^[A-Za-z0-9_-]{3,30}$/', $code) !== 1) {
-            throw new InvalidArgumentException('Group code must contain only alphanumeric characters, dashes, or underscores.');
+            throw new InvalidArgumentException(__('Il codice del gruppo può contenere solo caratteri alfanumerici, trattini o underscore.', 'fp-restaurant-reservations'));
         }
 
         return strtolower($code);

--- a/src/Domain/Tables/REST.php
+++ b/src/Domain/Tables/REST.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FP\Resv\Domain\Tables;
 
+use FP\Resv\Core\Security;
 use InvalidArgumentException;
 use WP_Error;
 use WP_REST_Request;
@@ -11,7 +12,6 @@ use WP_REST_Response;
 use WP_REST_Server;
 use function add_action;
 use function count;
-use function current_user_can;
 use function is_array;
 use function register_rest_route;
 use function rest_ensure_response;
@@ -284,7 +284,7 @@ final class REST
 
     private function canManage(): bool
     {
-        return current_user_can('manage_options');
+        return Security::currentUserCanManage();
     }
 
     /**

--- a/src/Domain/Tables/Repository.php
+++ b/src/Domain/Tables/Repository.php
@@ -6,6 +6,7 @@ namespace FP\Resv\Domain\Tables;
 
 use RuntimeException;
 use wpdb;
+use function __;
 use function absint;
 use function array_fill;
 use function array_map;
@@ -99,7 +100,7 @@ final class Repository
 
         $result = $this->wpdb->insert($this->roomsTable(), $payload);
         if ($result === false) {
-            throw new RuntimeException($this->wpdb->last_error ?: 'Unable to create room.');
+            throw new RuntimeException($this->wpdb->last_error ?: __('Impossibile creare la sala.', 'fp-restaurant-reservations'));
         }
 
         return (int) $this->wpdb->insert_id;
@@ -139,7 +140,7 @@ final class Repository
         );
 
         if ($updated === false) {
-            throw new RuntimeException($this->wpdb->last_error ?: 'Unable to update room.');
+            throw new RuntimeException($this->wpdb->last_error ?: __('Impossibile aggiornare la sala.', 'fp-restaurant-reservations'));
         }
     }
 
@@ -199,7 +200,7 @@ final class Repository
 
         $result = $this->wpdb->insert($this->tablesTable(), $payload);
         if ($result === false) {
-            throw new RuntimeException($this->wpdb->last_error ?: 'Unable to create table.');
+            throw new RuntimeException($this->wpdb->last_error ?: __('Impossibile creare il tavolo.', 'fp-restaurant-reservations'));
         }
 
         return (int) $this->wpdb->insert_id;
@@ -220,7 +221,7 @@ final class Repository
         );
 
         if ($updated === false) {
-            throw new RuntimeException($this->wpdb->last_error ?: 'Unable to update table.');
+            throw new RuntimeException($this->wpdb->last_error ?: __('Impossibile aggiornare il tavolo.', 'fp-restaurant-reservations'));
         }
     }
 
@@ -250,7 +251,7 @@ final class Repository
 
         $result = $this->wpdb->query($this->wpdb->prepare($sql, ...$params));
         if ($result === false) {
-            throw new RuntimeException($this->wpdb->last_error ?: 'Unable to update join group.');
+            throw new RuntimeException($this->wpdb->last_error ?: __('Impossibile aggiornare il gruppo di unione.', 'fp-restaurant-reservations'));
         }
     }
 
@@ -267,7 +268,7 @@ final class Repository
         );
 
         if ($updated === false) {
-            throw new RuntimeException($this->wpdb->last_error ?: 'Unable to update table position.');
+            throw new RuntimeException($this->wpdb->last_error ?: __('Impossibile aggiornare la posizione del tavolo.', 'fp-restaurant-reservations'));
         }
     }
 

--- a/src/Frontend/WidgetController.php
+++ b/src/Frontend/WidgetController.php
@@ -22,6 +22,7 @@ use function wp_enqueue_script;
 use function wp_enqueue_style;
 use function wp_register_script;
 use function wp_register_style;
+use function wp_set_script_translations;
 
 final class WidgetController
 {
@@ -79,6 +80,10 @@ final class WidgetController
 
         wp_enqueue_script(self::HANDLE_MODULE);
 
+        if (function_exists('wp_set_script_translations')) {
+            wp_set_script_translations(self::HANDLE_MODULE, 'fp-restaurant-reservations', Plugin::$dir . 'languages');
+        }
+
         if ($legacyExists) {
             wp_register_script(
                 self::HANDLE_LEGACY,
@@ -89,6 +94,10 @@ final class WidgetController
             );
 
             wp_enqueue_script(self::HANDLE_LEGACY);
+
+            if (function_exists('wp_set_script_translations')) {
+                wp_set_script_translations(self::HANDLE_LEGACY, 'fp-restaurant-reservations', Plugin::$dir . 'languages');
+            }
         }
     }
 

--- a/tests/Integration/Diagnostics/LoggingTest.php
+++ b/tests/Integration/Diagnostics/LoggingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Diagnostics;
+
+use FP\Resv\Core\Logging;
+use FP\Resv\Core\ServiceContainer;
+use FP\Resv\Domain\Diagnostics\Logger;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FakeWpdb;
+
+final class LoggingTest extends TestCase
+{
+    private FakeWpdb $wpdb;
+    private Logger $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->wpdb = new FakeWpdb();
+        $GLOBALS['wpdb'] = $this->wpdb;
+
+        $this->logger = new Logger($this->wpdb);
+        $container    = ServiceContainer::getInstance();
+        $container->register(Logger::class, $this->logger);
+        $container->register('diagnostics.logger', $this->logger);
+    }
+
+    public function testLogPersistsRow(): void
+    {
+        Logging::log('payments', 'Test message', [
+            'reservation_id' => 42,
+            'customer_id'    => 77,
+            'extra'          => 'value',
+        ]);
+
+        $rows = $this->logger->recent();
+
+        self::assertCount(1, $rows);
+        $row = $rows[0];
+        self::assertSame('payments', $row['channel']);
+        self::assertSame('Test message', $row['message']);
+        self::assertSame(42, (int) $row['reservation_id']);
+        self::assertSame(77, (int) $row['customer_id']);
+        self::assertNotEmpty($row['context_json']);
+    }
+}

--- a/tests/Integration/Reservations/AvailabilityTest.php
+++ b/tests/Integration/Reservations/AvailabilityTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Reservations;
+
+use FP\Resv\Domain\Reservations\Availability;
+use FP\Resv\Domain\Settings\Options;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FakeWpdb;
+
+final class AvailabilityTest extends TestCase
+{
+    private FakeWpdb $wpdb;
+    private Availability $availability;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->wpdb = new FakeWpdb();
+        $GLOBALS['wpdb'] = $this->wpdb;
+
+        update_option('fp_resv_general', [
+            'restaurant_timezone'      => 'Europe/Rome',
+            'service_hours_definition' => "sat=19:00-21:00",
+            'slot_interval_minutes'    => '60',
+            'table_turnover_minutes'   => '60',
+            'buffer_before_minutes'    => '0',
+            'max_parallel_parties'     => '5',
+            'enable_waitlist'          => '0',
+        ]);
+
+        update_option('fp_resv_rooms', [
+            'merge_strategy'        => 'smart',
+            'default_room_capacity' => '4',
+        ]);
+
+        $this->availability = new Availability(new Options(), $this->wpdb);
+    }
+
+    public function testSlotsMarkedFullWhenCapacityConsumed(): void
+    {
+        $this->wpdb->insert('wp_fp_rooms', [
+            'id'       => 1,
+            'capacity' => 4,
+            'active'   => 1,
+        ]);
+
+        $this->wpdb->insert('wp_fp_reservations', [
+            'id'      => 1,
+            'date'    => '2024-05-04',
+            'time'    => '19:00:00',
+            'party'   => 2,
+            'status'  => 'confirmed',
+            'room_id' => null,
+            'table_id'=> null,
+        ]);
+
+        $this->wpdb->insert('wp_fp_reservations', [
+            'id'      => 2,
+            'date'    => '2024-05-04',
+            'time'    => '19:00:00',
+            'party'   => 2,
+            'status'  => 'confirmed',
+            'room_id' => null,
+            'table_id'=> null,
+        ]);
+
+        $result = $this->availability->findSlots([
+            'date'  => '2024-05-04',
+            'party' => 2,
+        ]);
+
+        self::assertSame('full', $result['slots'][0]['status']);
+    }
+
+    public function testRoomFilterIgnoresReservationsFromOtherRooms(): void
+    {
+        update_option('fp_resv_rooms', [
+            'merge_strategy'        => 'smart',
+            'default_room_capacity' => '8',
+        ]);
+
+        $this->availability = new Availability(new Options(), $this->wpdb);
+
+        $this->wpdb->insert('wp_fp_rooms', [
+            'id'       => 1,
+            'capacity' => 8,
+            'active'   => 1,
+        ]);
+
+        $this->wpdb->insert('wp_fp_rooms', [
+            'id'       => 2,
+            'capacity' => 8,
+            'active'   => 1,
+        ]);
+
+        $this->wpdb->insert('wp_fp_reservations', [
+            'id'      => 3,
+            'date'    => '2024-05-04',
+            'time'    => '19:00:00',
+            'party'   => 4,
+            'status'  => 'confirmed',
+            'room_id' => 2,
+            'table_id'=> null,
+        ]);
+
+        $result = $this->availability->findSlots([
+            'date'  => '2024-05-04',
+            'party' => 2,
+            'room'  => 1,
+        ]);
+
+        self::assertSame('available', $result['slots'][0]['status']);
+        self::assertTrue($result['meta']['has_availability']);
+    }
+
+    public function testLocationFilterExcludesOtherLocations(): void
+    {
+        $this->wpdb->insert('wp_fp_rooms', [
+            'id'       => 1,
+            'capacity' => 8,
+            'active'   => 1,
+        ]);
+
+        $this->wpdb->insert('wp_fp_reservations', [
+            'id'          => 10,
+            'date'        => '2024-05-04',
+            'time'        => '19:00:00',
+            'party'       => 6,
+            'status'      => 'confirmed',
+            'room_id'     => null,
+            'table_id'    => null,
+            'location_id' => 'downtown',
+        ]);
+
+        $this->wpdb->insert('wp_fp_reservations', [
+            'id'          => 11,
+            'date'        => '2024-05-04',
+            'time'        => '19:00:00',
+            'party'       => 6,
+            'status'      => 'confirmed',
+            'room_id'     => null,
+            'table_id'    => null,
+            'location_id' => 'uptown',
+        ]);
+
+        $result = $this->availability->findSlots([
+            'date'     => '2024-05-04',
+            'party'    => 2,
+            'location' => 'downtown',
+        ]);
+
+        self::assertSame('limited', $result['slots'][0]['status']);
+        self::assertTrue($result['meta']['has_availability']);
+    }
+
+    public function testClosureBlocksRequestedSlots(): void
+    {
+        $this->wpdb->insert('wp_fp_rooms', [
+            'id'       => 1,
+            'capacity' => 4,
+            'active'   => 1,
+        ]);
+
+        $this->wpdb->insert('wp_fp_closures', [
+            'id'                     => 1,
+            'scope'                  => 'restaurant',
+            'room_id'                => null,
+            'table_id'               => null,
+            'type'                   => 'full',
+            'start_at'               => '2024-05-04 18:00:00',
+            'end_at'                 => '2024-05-04 22:00:00',
+            'recurrence_json'        => null,
+            'capacity_override_json' => null,
+            'active'                 => 1,
+        ]);
+
+        $result = $this->availability->findSlots([
+            'date'  => '2024-05-04',
+            'party' => 2,
+        ]);
+
+        self::assertSame('blocked', $result['slots'][0]['status']);
+        self::assertFalse($result['meta']['has_availability']);
+        self::assertNotEmpty($result['slots'][0]['reasons']);
+    }
+}

--- a/tests/Integration/Reservations/RestTest.php
+++ b/tests/Integration/Reservations/RestTest.php
@@ -7,6 +7,8 @@ namespace Tests\Integration\Reservations;
 use FP\Resv\Domain\Reservations\Availability;
 use FP\Resv\Domain\Reservations\REST;
 use FP\Resv\Domain\Reservations\Service;
+use FP\Resv\Domain\Settings\Options;
+use Tests\Support\FakeWpdb;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use WP_Error;
@@ -24,7 +26,14 @@ final class RestTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->availability = $this->createMock(Availability::class);
+
+        $wpdb = new FakeWpdb();
+        $GLOBALS['wpdb'] = $wpdb;
+
+        update_option('fp_resv_general', []);
+        update_option('fp_resv_rooms', []);
+
+        $this->availability = new Availability(new Options(), $wpdb);
         $this->service      = $this->createMock(Service::class);
     }
 
@@ -59,6 +68,21 @@ final class RestTest extends TestCase
             'fp_resv_email'      => 'ada@example.test',
             'fp_resv_date'       => '2024-05-11',
             'fp_resv_time'       => '21:00',
+            'fp_resv_meal'       => 'dinner',
+            'fp_resv_status'     => 'confirmed',
+            'fp_resv_room_id'    => '3',
+            'fp_resv_table_id'   => '5',
+            'fp_resv_phone'      => '+39 055 123456',
+            'fp_resv_phone_e164' => '+39055123456',
+            'fp_resv_phone_cc'   => 'IT',
+            'fp_resv_phone_local'=> '055 123456',
+            'fp_resv_price_per_person' => '49.90',
+            'utm_content'       => 'hero-banner',
+            'utm_term'          => 'romantic',
+            'gclid'             => 'test-gclid',
+            'fbclid'            => 'test-fbclid',
+            'msclkid'           => 'test-msclkid',
+            'ttclid'            => 'test-ttclid',
         ]);
 
         $this->service
@@ -68,7 +92,22 @@ final class RestTest extends TestCase
                 return $payload['party'] === 3
                     && $payload['first_name'] === 'Ada'
                     && $payload['last_name'] === 'Lovelace'
-                    && $payload['email'] === 'ada@example.test';
+                    && $payload['email'] === 'ada@example.test'
+                    && $payload['meal'] === 'dinner'
+                    && $payload['status'] === 'confirmed'
+                    && $payload['room_id'] === '3'
+                    && $payload['table_id'] === '5'
+                    && $payload['phone'] === '+39 055 123456'
+                    && $payload['phone_e164'] === '+39055123456'
+                    && $payload['phone_country'] === 'IT'
+                    && $payload['phone_national'] === '055 123456'
+                    && $payload['price_per_person'] === '49.90'
+                    && $payload['utm_content'] === 'hero-banner'
+                    && $payload['utm_term'] === 'romantic'
+                    && $payload['gclid'] === 'test-gclid'
+                    && $payload['fbclid'] === 'test-fbclid'
+                    && $payload['msclkid'] === 'test-msclkid'
+                    && $payload['ttclid'] === 'test-ttclid';
             }))
             ->willReturn([
                 'id'         => 123,

--- a/tests/Integration/Reservations/ServiceTest.php
+++ b/tests/Integration/Reservations/ServiceTest.php
@@ -9,8 +9,10 @@ use FP\Resv\Core\Mailer;
 use FP\Resv\Domain\Customers\Repository as CustomersRepository;
 use FP\Resv\Domain\Payments\Repository as PaymentsRepository;
 use FP\Resv\Domain\Payments\StripeService;
+use FP\Resv\Domain\Reservations\Availability;
 use FP\Resv\Domain\Reservations\Repository as ReservationsRepository;
 use FP\Resv\Domain\Reservations\Service;
+use FP\Resv\Domain\Tables\Repository as TablesRepository;
 use FP\Resv\Domain\Settings\Language;
 use FP\Resv\Domain\Settings\Options;
 use PHPUnit\Framework\TestCase;
@@ -32,6 +34,17 @@ final class ServiceTest extends TestCase
             'default_currency'           => 'EUR',
             'restaurant_name'            => 'La Pergola',
             'restaurant_timezone'        => 'Europe/Rome',
+            'service_hours_definition'   => "sat=19:00-23:00\nsun=19:00-23:00\nmon=19:00-23:00",
+            'slot_interval_minutes'      => '15',
+            'table_turnover_minutes'     => '120',
+            'buffer_before_minutes'      => '0',
+            'max_parallel_parties'       => '6',
+            'enable_waitlist'            => '0',
+        ]);
+
+        update_option('fp_resv_rooms', [
+            'merge_strategy'        => 'smart',
+            'default_room_capacity' => '4',
         ]);
 
         update_option('fp_resv_notifications', [
@@ -50,6 +63,14 @@ final class ServiceTest extends TestCase
         update_option('fp_resv_payments', [
             'stripe_enabled' => '0',
         ]);
+
+        $this->wpdb->insert('wp_fp_rooms', [
+            'id'          => 1,
+            'name'        => 'Sala Principale',
+            'capacity'    => 4,
+            'active'      => 1,
+            'order_index' => 0,
+        ]);
     }
 
     public function testCreateReservationPersistsDataAndSendsEmails(): void
@@ -60,28 +81,14 @@ final class ServiceTest extends TestCase
         Consent::init($options);
 
         $language     = new Language($options);
-        $mailer       = new class extends Mailer {
-            /** @var array<int, array<string, mixed>> */
-            public array $sent = [];
-
-            public function send(
-                string $to,
-                string $subject,
-                string $message,
-                array $headers = [],
-                array $attachments = [],
-                array $context = []
-            ): bool {
-                $this->sent[] = compact('to', 'subject', 'message', 'headers', 'attachments', 'context');
-
-                return true;
-            }
-        };
+        $mailer       = new Mailer();
 
         $reservations = new ReservationsRepository($this->wpdb);
         $customers    = new CustomersRepository($this->wpdb);
         $paymentsRepo = new PaymentsRepository($this->wpdb);
         $stripe       = new StripeService($options, $paymentsRepo);
+        $tables       = new TablesRepository($this->wpdb);
+        $availability = new Availability($options, $this->wpdb);
 
         $service = new Service(
             $reservations,
@@ -90,6 +97,8 @@ final class ServiceTest extends TestCase
             $mailer,
             $customers,
             $stripe,
+            $tables,
+            $availability,
             null
         );
 
@@ -101,6 +110,9 @@ final class ServiceTest extends TestCase
             'last_name'   => 'Lovelace',
             'email'       => 'ada@example.test',
             'phone'       => '+39 055 123456',
+            'phone_e164'  => '+39055123456',
+            'phone_country' => 'IT',
+            'phone_national'=> '055 123456',
             'notes'       => 'Niente glutine',
             'allergies'   => 'Glutine',
             'language'    => 'it',
@@ -116,28 +128,220 @@ final class ServiceTest extends TestCase
         self::assertSame('confirmed', $result['status']);
         self::assertStringContainsString('fp_resv_manage=', $result['manage_url']);
 
-        $reservationsTable = $this->wpdb->get_table($reservations->tableName());
+        $reservationsTable = array_values($this->wpdb->get_table($reservations->tableName()));
         self::assertCount(1, $reservationsTable);
-        $stored = $reservationsTable[1];
+        $stored = $reservationsTable[0];
         self::assertSame('confirmed', $stored['status']);
         self::assertSame('20:15:00', $stored['time']);
         self::assertSame('newsletter', $stored['utm_source']);
         self::assertSame('EUR', $stored['currency']);
 
-        $customersTable = $this->wpdb->get_table($customers->tableName());
+        $customersTable = array_values($this->wpdb->get_table($customers->tableName()));
         self::assertCount(1, $customersTable);
-        $customer = $customersTable[1];
+        $customer = $customersTable[0];
         self::assertSame('ada@example.test', $customer['email']);
         self::assertSame('it', $customer['lang']);
+        self::assertSame('+39055123456', $customer['phone_e164']);
+        self::assertSame('IT', $customer['phone_country']);
+        self::assertSame('055 123456', $customer['phone_national']);
 
-        self::assertNotEmpty($mailer->sent);
-        $customerMail = $mailer->sent[0];
+        $mailLog = array_values($GLOBALS['__wp_tests_mail_log']);
+        self::assertNotEmpty($mailLog);
+
+        $customerMail = $mailLog[0];
         self::assertSame('ada@example.test', $customerMail['to']);
         self::assertStringContainsString('La tua prenotazione', $customerMail['subject']);
+    }
 
-        $staffMail = $mailer->sent[1];
-        self::assertSame('staff@example.test', $staffMail['to']);
-        self::assertSame('restaurant_notification', $staffMail['context']['channel']);
+    public function testDuplicateReservationIsRejected(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '198.51.100.50';
+
+        $options      = new Options();
+        Consent::init($options);
+
+        $language     = new Language($options);
+        $mailer       = new Mailer();
+
+        $reservations = new ReservationsRepository($this->wpdb);
+        $customers    = new CustomersRepository($this->wpdb);
+        $paymentsRepo = new PaymentsRepository($this->wpdb);
+        $stripe       = new StripeService($options, $paymentsRepo);
+        $tables       = new TablesRepository($this->wpdb);
+        $availability = new Availability($options, $this->wpdb);
+
+        $service = new Service(
+            $reservations,
+            $options,
+            $language,
+            $mailer,
+            $customers,
+            $stripe,
+            $tables,
+            $availability,
+            null
+        );
+
+        $payload = [
+            'date'        => '2024-05-04',
+            'time'        => '20:15',
+            'party'       => 2,
+            'first_name'  => 'Grace',
+            'last_name'   => 'Hopper',
+            'email'       => 'grace@example.test',
+            'phone'       => '+39 06 1234567',
+            'phone_e164'  => '+39061234567',
+            'phone_country' => 'IT',
+            'phone_national'=> '06 1234567',
+            'language'    => 'it',
+            'locale'      => 'it_IT',
+            'location'    => 'roma',
+        ];
+
+        $service->create($payload);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Esiste già una prenotazione');
+
+        $service->create($payload);
+    }
+
+    public function testReservationRejectedWhenSlotIsFull(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '198.51.100.61';
+
+        $options      = new Options();
+        Consent::init($options);
+
+        $language     = new Language($options);
+        $mailer       = new Mailer();
+
+        $reservations = new ReservationsRepository($this->wpdb);
+        $customers    = new CustomersRepository($this->wpdb);
+        $paymentsRepo = new PaymentsRepository($this->wpdb);
+        $stripe       = new StripeService($options, $paymentsRepo);
+        $tables       = new TablesRepository($this->wpdb);
+        $availability = new Availability($options, $this->wpdb);
+
+        // Saturate the slot by creating a reservation that consumes all capacity.
+        $reservations->insert([
+            'status'   => 'confirmed',
+            'date'     => '2024-05-04',
+            'time'     => '20:15:00',
+            'party'    => 4,
+            'customer_id' => null,
+            'room_id'  => null,
+            'location_id' => 'default',
+        ]);
+
+        $service = new Service(
+            $reservations,
+            $options,
+            $language,
+            $mailer,
+            $customers,
+            $stripe,
+            $tables,
+            $availability,
+            null
+        );
+
+        $result = $availability->findSlots([
+            'date'     => '2024-05-04',
+            'party'    => 2,
+            'location' => 'default',
+        ]);
+
+        $targetSlot = null;
+        foreach ($result['slots'] as $slot) {
+            if (($slot['label'] ?? '') === '20:15') {
+                $targetSlot = $slot;
+                break;
+            }
+        }
+
+        self::assertIsArray($targetSlot);
+        self::assertSame('full', $targetSlot['status']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Il turno selezionato');
+
+        $service->create([
+            'date'        => '2024-05-04',
+            'time'        => '20:15',
+            'party'       => 2,
+            'first_name'  => 'Maria',
+            'last_name'   => 'Rossi',
+            'email'       => 'maria@example.test',
+            'phone'       => '+39 055 111111',
+        ]);
+    }
+
+    public function testManageTokenExpires(): void
+    {
+        $service = $this->makeService();
+
+        $filter = static function (): int {
+            return 60;
+        };
+
+        add_filter('fp_resv_manage_token_ttl', $filter);
+
+        $result = $service->create([
+            'date'        => '2024-05-06',
+            'time'        => '19:30',
+            'party'       => 3,
+            'first_name'  => 'Laura',
+            'last_name'   => 'Verdi',
+            'email'       => 'laura@example.test',
+            'phone'       => '+39 02 654321',
+        ]);
+
+        remove_filter('fp_resv_manage_token_ttl', $filter);
+
+        $reservationId = (int) ($result['id'] ?? 0);
+        self::assertGreaterThan(0, $reservationId);
+
+        $parsed = wp_parse_url((string) ($result['manage_url'] ?? ''));
+        parse_str($parsed['query'] ?? '', $params);
+        $token = (string) ($params['fp_resv_token'] ?? '');
+
+        self::assertNotSame('', $token);
+        self::assertTrue($service->verifyManageToken($reservationId, 'laura@example.test', $token));
+
+        $store = get_option('fp_resv_manage_tokens', []);
+        $store[$token]['expires_at'] = time() - 10;
+        update_option('fp_resv_manage_tokens', $store);
+
+        self::assertFalse($service->verifyManageToken($reservationId, 'laura@example.test', $token));
+
+        delete_option('fp_resv_manage_tokens');
+    }
+
+    private function makeService(): Service
+    {
+        $options      = new Options();
+        Consent::init($options);
+        $language     = new Language($options);
+        $mailer       = new Mailer();
+        $reservations = new ReservationsRepository($this->wpdb);
+        $customers    = new CustomersRepository($this->wpdb);
+        $paymentsRepo = new PaymentsRepository($this->wpdb);
+        $stripe       = new StripeService($options, $paymentsRepo);
+        $tables       = new TablesRepository($this->wpdb);
+        $availability = new Availability($options, $this->wpdb);
+
+        return new Service(
+            $reservations,
+            $options,
+            $language,
+            $mailer,
+            $customers,
+            $stripe,
+            $tables,
+            $availability,
+            null
+        );
     }
 }
 

--- a/tests/Unit/Core/HelpersTest.php
+++ b/tests/Unit/Core/HelpersTest.php
@@ -30,6 +30,22 @@ final class HelpersTest extends TestCase
         self::assertSame('198.51.100.20', Helpers::clientIp());
     }
 
+    public function testIgnoresInvalidForwardedIps(): void
+    {
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = 'invalid, also invalid';
+        $_SERVER['REMOTE_ADDR']          = '198.51.100.30';
+
+        self::assertSame('198.51.100.30', Helpers::clientIp());
+    }
+
+    public function testSanitizesCloudflareHeader(): void
+    {
+        $_SERVER['HTTP_CF_CONNECTING_IP'] = '2001:db8::1 ';
+        $_SERVER['REMOTE_ADDR']           = '198.51.100.40';
+
+        self::assertSame('2001:db8::1', Helpers::clientIp());
+    }
+
     public function testReturnsDefaultWhenNoHeaderIsPresent(): void
     {
         self::assertSame('0.0.0.0', Helpers::clientIp());

--- a/tests/Unit/Core/RateLimiterTest.php
+++ b/tests/Unit/Core/RateLimiterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core;
+
+use FP\Resv\Core\RateLimiter;
+use PHPUnit\Framework\TestCase;
+
+final class RateLimiterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['__wp_tests_transients'] = [];
+    }
+
+    public function testAllowsWithinLimit(): void
+    {
+        $result = RateLimiter::check('example', 2, 60);
+
+        self::assertTrue($result['allowed']);
+        self::assertSame(1, $result['remaining']);
+        self::assertSame(0, $result['retry_after']);
+    }
+
+    public function testBlocksWhenLimitExceeded(): void
+    {
+        RateLimiter::check('limited', 1, 60);
+        $result = RateLimiter::check('limited', 1, 60);
+
+        self::assertFalse($result['allowed']);
+        self::assertGreaterThan(0, $result['retry_after']);
+        self::assertSame(0, $result['remaining']);
+    }
+}

--- a/tests/Unit/Core/ValidatorTest.php
+++ b/tests/Unit/Core/ValidatorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core;
+
+use FP\Resv\Core\Validator;
+use PHPUnit\Framework\TestCase;
+
+final class ValidatorTest extends TestCase
+{
+    public function testSanitizePreservesPrimitiveTypes(): void
+    {
+        $input = [
+            'string'  => '  Hello <strong>World</strong>  ',
+            'multiline' => "Line 1\nLine 2",
+            'int'     => 42,
+            'float'   => 9.99,
+            'bool'    => true,
+            'null'    => null,
+            'array'   => [
+                'nested_string' => ' Foo ',
+                'nested_bool'   => false,
+                'nested_array'  => [
+                    'deep' => "Deep\nValue",
+                ],
+            ],
+        ];
+
+        $result = Validator::sanitize($input);
+
+        self::assertSame('Hello World', $result['string']);
+        self::assertSame("Line 1\nLine 2", $result['multiline']);
+        self::assertSame(42, $result['int']);
+        self::assertSame(9.99, $result['float']);
+        self::assertTrue($result['bool']);
+        self::assertNull($result['null']);
+        self::assertSame('Foo', $result['array']['nested_string']);
+        self::assertFalse($result['array']['nested_bool']);
+        self::assertSame('Deep' . PHP_EOL . 'Value', $result['array']['nested_array']['deep']);
+    }
+}

--- a/tests/Unit/Domain/Tracking/ManagerTest.php
+++ b/tests/Unit/Domain/Tracking/ManagerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Tracking;
+
+use FP\Resv\Core\Consent;
+use FP\Resv\Domain\Settings\Options;
+use FP\Resv\Domain\Tracking\Ads;
+use FP\Resv\Domain\Tracking\Clarity;
+use FP\Resv\Domain\Tracking\GA4;
+use FP\Resv\Domain\Tracking\Manager;
+use FP\Resv\Domain\Tracking\Meta;
+use PHPUnit\Framework\TestCase;
+
+final class ManagerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_GET = [];
+        $_COOKIE = [];
+        update_option('fp_resv_tracking', [
+            'tracking_utm_cookie_days' => '30',
+        ]);
+    }
+
+    public function testCaptureQueuesUntilConsentGranted(): void
+    {
+        $_GET['utm_source'] = 'newsletter';
+        $_GET['utm_campaign'] = 'spring';
+
+        $options = new Options();
+        Consent::init($options);
+        Consent::update([
+            'analytics' => 'denied',
+            'ads'       => 'denied',
+        ]);
+
+        $manager = new Manager(
+            $options,
+            new GA4($options),
+            new Ads($options),
+            new Meta($options),
+            new Clarity($options)
+        );
+
+        $manager->captureAttribution();
+
+        $queue = get_option('fp_resv_pending_attribution', []);
+        self::assertIsArray($queue);
+        self::assertCount(1, $queue);
+        self::assertSame('newsletter', $queue[0]['values']['utm_source']);
+
+        Consent::update([
+            'analytics' => 'granted',
+            'ads'       => 'granted',
+        ]);
+
+        self::assertTrue(Consent::has('analytics'));
+        self::assertTrue(Consent::has('ads'));
+
+        $manager->captureAttribution();
+        $manager->maybeFlushPendingAttribution();
+
+        $queue = get_option('fp_resv_pending_attribution', []);
+        self::assertIsArray($queue);
+        self::assertSame([], $queue);
+    }
+}

--- a/tests/Unit/Payments/StripeServiceTest.php
+++ b/tests/Unit/Payments/StripeServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Payments;
+
+use FP\Resv\Domain\Payments\StripeService;
+use FP\Resv\Domain\Settings\Options;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FakeWpdb;
+use FP\Resv\Domain\Payments\Repository;
+
+final class StripeServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        update_option('fp_resv_payments', []);
+    }
+
+    public function testCalculateReservationAmountUsesDepositForCaptureStrategy(): void
+    {
+        update_option('fp_resv_payments', [
+            'stripe_enabled'        => '1',
+            'stripe_capture_type'   => 'deposit',
+            'stripe_deposit_amount' => '15',
+        ]);
+
+        $service = new StripeService(new Options(), new Repository(new FakeWpdb()));
+
+        $amount = $service->calculateReservationAmount(['party' => 3], 42);
+
+        self::assertSame(45.0, $amount);
+    }
+
+    public function testCalculateReservationAmountPrefersSubmittedValue(): void
+    {
+        update_option('fp_resv_payments', [
+            'stripe_capture_type'   => 'authorization',
+            'stripe_deposit_amount' => '20',
+        ]);
+
+        $service = new StripeService(new Options(), new Repository(new FakeWpdb()));
+
+        $amount = $service->calculateReservationAmount([
+            'party' => 2,
+            'value' => 75,
+        ], 5);
+
+        self::assertSame(75.0, $amount);
+    }
+
+    public function testShouldRequireReservationPaymentWhenEnabledAndPositiveAmount(): void
+    {
+        update_option('fp_resv_payments', [
+            'stripe_enabled'        => '1',
+            'stripe_capture_type'   => 'authorization',
+            'stripe_deposit_amount' => '10',
+        ]);
+
+        $service = new StripeService(new Options(), new Repository(new FakeWpdb()));
+
+        self::assertTrue($service->shouldRequireReservationPayment(['party' => 2]));
+
+        update_option('fp_resv_payments', [
+            'stripe_enabled' => '0',
+        ]);
+
+        $disabled = new StripeService(new Options(), new Repository(new FakeWpdb()));
+        self::assertFalse($disabled->shouldRequireReservationPayment(['party' => 2]));
+    }
+
+    public function testToMinorUnitsHandlesZeroDecimalCurrencies(): void
+    {
+        update_option('fp_resv_payments', []);
+        $service = new StripeService(new Options(), new Repository(new FakeWpdb()));
+
+        $method = new \ReflectionMethod($service, 'toMinorUnits');
+        $method->setAccessible(true);
+
+        self::assertSame(1234, $method->invoke($service, 12.34, 'eur'));
+        self::assertSame(13, $method->invoke($service, 12.7, 'JPY'));
+    }
+}


### PR DESCRIPTION
## Summary
- implement recursive sanitizer coverage for mixed payloads and add a unit test for Validator::sanitize
- add reservation manage-token persistence/CLI and availability cache flushing, wiring the new helpers through the plugin
- re-check slot availability before inserts, expand schema/anonymization, and update integration tests for the tightened behaviour

## Testing
- ./vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68dc3e1af20c832f9f074626235157b9