### PR TITLE
Add backend agenda REST coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "vite build",
     "dev": "vite",
     "test": "npm run test:phpunit",
-    "test:phpunit": "phpunit -c tests/phpunit.xml",
+    "test:phpunit": "./vendor/bin/phpunit -c tests/phpunit.xml",
     "test:e2e": "playwright test --config tests/E2E/playwright.config.ts"
   },
   "devDependencies": {

--- a/src/Domain/Reservations/Availability.php
+++ b/src/Domain/Reservations/Availability.php
@@ -32,7 +32,7 @@ use function trim;
 use const ARRAY_A;
 use wpdb;
 
-final class Availability
+class Availability
 {
     private const DEFAULT_TIMEZONE = 'Europe/Rome';
 

--- a/src/Domain/Reservations/REST.php
+++ b/src/Domain/Reservations/REST.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace FP\Resv\Domain\Reservations;
 
+use FP\Resv\Core\DataLayer;
 use FP\Resv\Core\Helpers;
 use FP\Resv\Core\RateLimiter;
 use FP\Resv\Domain\Reservations\Service;

--- a/src/Domain/Reservations/Service.php
+++ b/src/Domain/Reservations/Service.php
@@ -59,7 +59,7 @@ use function wp_json_encode;
 use function wp_salt;
 use const FILTER_VALIDATE_EMAIL;
 
-final class Service
+class Service
 {
     public const ALLOWED_STATUSES = [
         'pending',

--- a/tests/Support/FakeWpdb.php
+++ b/tests/Support/FakeWpdb.php
@@ -6,7 +6,7 @@ namespace Tests\Support;
 
 use RuntimeException;
 
-class FakeWpdb
+class FakeWpdb extends \wpdb
 {
     public string $prefix = 'wp_';
     public int $insert_id = 0;
@@ -15,18 +15,30 @@ class FakeWpdb
     /** @var array<string, array<int, array<string, mixed>>> */
     private array $tables = [];
 
+    /** @var array<string, int> */
+    private array $autoIncrement = [];
+
     /**
      * @param array<string, mixed> $data
      */
     public function insert(string $table, array $data): int
     {
-        $id = $data['id'] ?? ($this->insert_id + 1);
-        $this->insert_id = (int) $id;
+        $table = $this->normalizeTable($table);
+
+        if (isset($data['id']) && (int) $data['id'] > 0) {
+            $id = (int) $data['id'];
+        } else {
+            $nextId = ($this->autoIncrement[$table] ?? 0) + 1;
+            $this->autoIncrement[$table] = $nextId;
+            $id = $nextId;
+        }
+
+        $this->insert_id = $id;
 
         $row       = $data;
-        $row['id'] = $this->insert_id;
+        $row['id'] = $id;
 
-        $this->tables[$table][$this->insert_id] = $row;
+        $this->tables[$table][$id] = $row;
 
         return 1;
     }
@@ -37,6 +49,8 @@ class FakeWpdb
      */
     public function update(string $table, array $data, array $where): int
     {
+        $table = $this->normalizeTable($table);
+
         $id = $where['id'] ?? null;
         if ($id === null) {
             throw new RuntimeException('FakeWpdb::update requires an id condition.');
@@ -102,12 +116,89 @@ class FakeWpdb
             $reservationsTable = $this->normalizeTable($matches[1]);
             $customersTable    = $this->normalizeTable($matches[2]);
 
+            $tablesTable = null;
+            if (preg_match('/LEFT\s+JOIN\s+([`\\w]+)\s+t\s+ON/i', $query, $tableMatches) === 1) {
+                $tablesTable = $this->normalizeTable($tableMatches[1]);
+            }
+
+            $roomsTable = null;
+            if (preg_match('/LEFT\s+JOIN\s+([`\\w]+)\s+rm\s+ON/i', $query, $roomMatches) === 1) {
+                $roomsTable = $this->normalizeTable($roomMatches[1]);
+            }
+
+            $startDate = null;
+            $endDate   = null;
+            if (preg_match("/BETWEEN\s+'([^']+)'\s+AND\s+'([^']+)'/i", $query, $rangeMatches) === 1) {
+                $startDate = $rangeMatches[1];
+                $endDate   = $rangeMatches[2];
+            }
+
             $rows = [];
             foreach ($this->tables[$reservationsTable] ?? [] as $row) {
+                $date = (string) ($row['date'] ?? '');
+                if ($startDate !== null && $endDate !== null) {
+                    if ($date < $startDate || $date > $endDate) {
+                        continue;
+                    }
+                }
+
                 $customerId = (int) ($row['customer_id'] ?? 0);
                 $customer   = $this->tables[$customersTable][$customerId] ?? [];
-                $rows[]     = array_merge($row, $customer);
+
+                $tableData = [];
+                if ($tablesTable !== null) {
+                    $tableId   = (int) ($row['table_id'] ?? 0);
+                    $tableData = $this->tables[$tablesTable][$tableId] ?? [];
+                }
+
+                $roomData = [];
+                if ($roomsTable !== null) {
+                    $roomId   = (int) ($row['room_id'] ?? 0);
+                    $roomData = $this->tables[$roomsTable][$roomId] ?? [];
+                }
+
+                $rows[] = array_merge(
+                    $row,
+                    [
+                        'first_name'     => $customer['first_name'] ?? ($row['first_name'] ?? null),
+                        'last_name'      => $customer['last_name'] ?? ($row['last_name'] ?? null),
+                        'email'          => $customer['email'] ?? ($row['email'] ?? null),
+                        'phone'          => $customer['phone'] ?? ($row['phone'] ?? null),
+                        'customer_lang'  => $customer['lang'] ?? ($row['customer_lang'] ?? null),
+                        'table_code'     => $tableData['code'] ?? ($row['table_code'] ?? null),
+                        'room_name'      => $roomData['name'] ?? ($row['room_name'] ?? null),
+                    ]
+                );
             }
+
+            usort($rows, static function (array $left, array $right): int {
+                $dateComparison = (($left['date'] ?? '') <=> ($right['date'] ?? ''));
+                if ($dateComparison !== 0) {
+                    return $dateComparison;
+                }
+
+                return (($left['time'] ?? '') <=> ($right['time'] ?? ''));
+            });
+
+            return $rows;
+        }
+
+        if (preg_match('/SELECT\s+\*\s+FROM\s+([`\\w]+)(?:\s+WHERE\s+room_id\s*=\s*(\d+))?.*ORDER\s+BY/i', $query, $matches) === 1) {
+            $table  = $this->normalizeTable($matches[1]);
+            $roomId = isset($matches[2]) ? (int) $matches[2] : null;
+
+            $rows = array_values($this->tables[$table] ?? []);
+
+            if ($roomId !== null) {
+                $rows = array_values(array_filter($rows, static fn (array $row): bool => (int) ($row['room_id'] ?? 0) === $roomId));
+            }
+
+            usort($rows, static function (array $left, array $right): int {
+                $leftOrder  = sprintf('%05d-%05d-%s', (int) ($left['room_id'] ?? 0), (int) ($left['order_index'] ?? 0), (string) ($left['code'] ?? ''));
+                $rightOrder = sprintf('%05d-%05d-%s', (int) ($right['room_id'] ?? 0), (int) ($right['order_index'] ?? 0), (string) ($right['code'] ?? ''));
+
+                return $leftOrder <=> $rightOrder;
+            });
 
             return $rows;
         }
@@ -117,6 +208,8 @@ class FakeWpdb
 
     public function get_table(string $table): array
     {
+        $table = $this->normalizeTable($table);
+
         return $this->tables[$table] ?? [];
     }
 

--- a/tests/Unit/Core/ICSTest.php
+++ b/tests/Unit/Core/ICSTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use FP\Resv\Core\ICS;
+use PHPUnit\Framework\TestCase;
+
+final class ICSTest extends TestCase
+{
+    public function testGeneratesEscapedCalendar(): void
+    {
+        $start = new DateTimeImmutable('2025-03-10 19:30:00', new DateTimeZone('UTC'));
+        $end   = $start->modify('+2 hours');
+
+        $ics = ICS::generate([
+            'uid' => 'test-uid',
+            'summary' => 'Cena speciale, degustazione',
+            'description' => "Prima linea\nSeconda; linea con ; e , e \\ backslash",
+            'location' => "Ristorante \"La, Pergola\"; Sala\nVIP",
+            'organizer' => 'mailto:host@example.com',
+            'url' => 'https://example.com/reservation?id=42',
+            'attendees' => [
+                'mailto:guest@example.com',
+                'mailto:vip@example.com',
+                '',
+                123,
+            ],
+            'start' => $start,
+            'end' => $end,
+            'timezone' => 'Europe/Rome',
+        ]);
+
+        self::assertStringContainsString('UID:test-uid', $ics);
+        self::assertStringContainsString('SUMMARY:Cena speciale\\, degustazione', $ics);
+        self::assertStringContainsString('DESCRIPTION:Prima linea\\nSeconda\\; linea con \\; e \\, e \\\\ backslash', $ics);
+        self::assertStringContainsString('LOCATION:Ristorante "La\\, Pergola"\\; Sala\\nVIP', $ics);
+        self::assertStringContainsString('DTSTART;TZID=Europe/Rome:20250310T203000', $ics);
+        self::assertStringContainsString('DTEND;TZID=Europe/Rome:20250310T223000', $ics);
+        self::assertStringContainsString('BEGIN:DAYLIGHT', $ics);
+        self::assertStringContainsString('BEGIN:STANDARD', $ics);
+        self::assertSame(2, substr_count($ics, 'ATTENDEE:mailto:'));
+    }
+
+    public function testFoldLineWrapsLongFieldsAndTerminatesWithCrLf(): void
+    {
+        $start = new DateTimeImmutable('2025-03-10 19:30:00', new DateTimeZone('UTC'));
+        $end   = $start->modify('+30 minutes');
+
+        $ics = ICS::generate([
+            'start' => $start,
+            'end' => $end,
+            'timezone' => 'Europe/Rome',
+            'summary' => str_repeat('A', 90),
+        ]);
+
+        self::assertStringContainsString("\r\n ", $ics);
+        self::assertStringEndsWith("\r\n", $ics);
+    }
+
+    public function testGeneratesStructuredAttendees(): void
+    {
+        $start = new DateTimeImmutable('2025-07-01 18:00:00', new DateTimeZone('UTC'));
+        $end   = $start->modify('+90 minutes');
+
+        $ics = ICS::generate([
+            'start' => $start,
+            'end' => $end,
+            'timezone' => 'Europe/Rome',
+            'attendees' => [
+                'mailto:string@example.com',
+                [
+                    'email' => 'guest@example.com',
+                    'name' => 'Mario Rossi',
+                    'role' => 'req-participant',
+                    'rsvp' => true,
+                ],
+                [
+                    'email' => 'mailto:manager@example.com',
+                    'name' => 'Responsabile; Eventi',
+                    'role' => 'chair',
+                    'rsvp' => false,
+                    'type' => 'resource',
+                    'status' => 'accepted',
+                ],
+                ['email' => '   '],
+                ['name' => 'Missing email'],
+            ],
+        ]);
+
+        $normalized = str_replace("\r\n ", '', $ics);
+
+        self::assertStringContainsString('ATTENDEE:mailto:string@example.com', $normalized);
+        self::assertStringContainsString('ATTENDEE;CN="Mario Rossi";ROLE=REQ-PARTICIPANT;RSVP=TRUE:mailto:guest@example.com', $normalized);
+        self::assertStringContainsString('ATTENDEE;CN="Responsabile; Eventi";ROLE=CHAIR;RSVP=FALSE;CUTYPE=RESOURCE;PARTSTAT=ACCEPTED:mailto:manager@example.com', $normalized);
+        self::assertSame(3, substr_count($normalized, 'ATTENDEE'));
+    }
+
+    public function testTimezoneTransitionsUseLocalTime(): void
+    {
+        $start = new DateTimeImmutable('2025-03-10 19:30:00', new DateTimeZone('UTC'));
+        $end   = $start->modify('+2 hours');
+
+        $ics = ICS::generate([
+            'start' => $start,
+            'end' => $end,
+            'timezone' => 'Europe/Rome',
+        ]);
+
+        $normalized = str_replace("\r\n ", '', $ics);
+
+        self::assertStringContainsString('BEGIN:DAYLIGHT', $normalized);
+        self::assertStringContainsString('DTSTART:20250330T030000', $normalized);
+        self::assertStringContainsString('BEGIN:STANDARD', $normalized);
+        self::assertStringContainsString('DTSTART:20251026T020000', $normalized);
+    }
+}

--- a/tests/Unit/Domain/Reservations/AdminRESTTest.php
+++ b/tests/Unit/Domain/Reservations/AdminRESTTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Reservations;
+
+use FP\Resv\Domain\Reservations\AdminREST;
+use FP\Resv\Domain\Reservations\Repository as ReservationsRepository;
+use FP\Resv\Domain\Reservations\Service;
+use FP\Resv\Domain\Tables\LayoutService;
+use FP\Resv\Domain\Tables\Repository as TablesRepository;
+use PHPUnit\Framework\TestCase;
+use WP_REST_Request;
+use WP_REST_Response;
+use Tests\Support\FakeWpdb;
+
+final class AdminRESTTest extends TestCase
+{
+    public function testHandleAgendaBuildsDaysAndTables(): void
+    {
+        $wpdb = new FakeWpdb();
+        $reservationsRepository = new ReservationsRepository($wpdb);
+        $tablesRepository       = new TablesRepository($wpdb);
+        $layout                 = new LayoutService($tablesRepository);
+
+        $service = $this->createStub(Service::class);
+
+        $wpdb->insert($tablesRepository->roomsTable(), [
+            'id'          => 2,
+            'name'        => 'Sala Principale',
+            'description' => 'Sala principale',
+            'color'       => '#ffffff',
+            'capacity'    => 40,
+            'order_index' => 1,
+            'active'      => 1,
+        ]);
+        $wpdb->insert($tablesRepository->roomsTable(), [
+            'id'          => 3,
+            'name'        => 'Sala Privata',
+            'description' => 'Sala privata',
+            'color'       => '#000000',
+            'capacity'    => 12,
+            'order_index' => 2,
+            'active'      => 1,
+        ]);
+
+        $wpdb->insert($tablesRepository->tablesTable(), [
+            'id'          => 7,
+            'room_id'     => 2,
+            'code'        => 'T1',
+            'seats_min'   => 2,
+            'seats_std'   => 4,
+            'seats_max'   => 6,
+            'status'      => 'available',
+            'active'      => 1,
+            'order_index' => 1,
+            'join_group'  => 'interni',
+        ]);
+        $wpdb->insert($tablesRepository->tablesTable(), [
+            'id'          => 9,
+            'room_id'     => 2,
+            'code'        => 'T2',
+            'seats_min'   => 2,
+            'seats_std'   => 4,
+            'seats_max'   => 4,
+            'status'      => 'maintenance',
+            'active'      => 0,
+            'order_index' => 2,
+            'join_group'  => 'interni',
+        ]);
+        $wpdb->insert($tablesRepository->tablesTable(), [
+            'id'          => 12,
+            'room_id'     => 3,
+            'code'        => 'P1',
+            'seats_min'   => 4,
+            'seats_std'   => 6,
+            'seats_max'   => 8,
+            'status'      => 'available',
+            'active'      => 1,
+            'order_index' => 1,
+        ]);
+
+        $wpdb->insert($reservationsRepository->customersTableName(), [
+            'id'         => 5,
+            'first_name' => 'Alice',
+            'last_name'  => 'Example',
+            'email'      => 'alice@example.test',
+            'phone'      => '+39012345678',
+            'lang'       => 'it',
+        ]);
+
+        $wpdb->insert($reservationsRepository->tableName(), [
+            'id'                    => 10,
+            'customer_id'           => 5,
+            'status'                => 'confirmed',
+            'date'                  => '2024-08-16',
+            'time'                  => '18:30:00',
+            'party'                 => 2,
+            'notes'                 => 'Niente cipolla',
+            'allergies'             => 'Glutine',
+            'room_id'               => 3,
+            'table_id'              => 7,
+            'visited_at'            => null,
+            'calendar_event_id'     => 'evt-1',
+            'calendar_sync_status'  => 'synced',
+            'calendar_synced_at'    => '2024-08-01 12:00:00',
+            'calendar_last_error'   => null,
+        ]);
+
+        $wpdb->insert($reservationsRepository->tableName(), [
+            'id'           => 11,
+            'status'       => 'pending',
+            'date'         => '2024-08-16',
+            'time'         => '19:15:00',
+            'party'        => 4,
+            'notes'        => '',
+            'allergies'    => '',
+            'room_id'      => null,
+            'table_id'     => null,
+            'customer_id'  => null,
+            'email'        => 'guest@example.test',
+            'customer_lang'=> 'en',
+        ]);
+
+        $rest = new AdminREST($reservationsRepository, $service, null, $layout);
+
+        $request = new WP_REST_Request([
+            'date' => '2024-08-16',
+            'range' => 'week',
+        ]);
+
+        $response = $rest->handleAgenda($request);
+
+        self::assertInstanceOf(WP_REST_Response::class, $response);
+        $data = $response->get_data();
+
+        self::assertSame([
+            'mode' => 'week',
+            'start' => '2024-08-16',
+            'end' => '2024-08-22',
+        ], $data['range']);
+        self::assertCount(2, $data['reservations']);
+        self::assertSame('confirmed', $data['reservations'][0]['status']);
+        self::assertSame('Alice', $data['reservations'][0]['customer']['first_name']);
+
+        self::assertCount(1, $data['days']);
+        $day = $data['days'][0];
+        self::assertSame('2024-08-16', $day['date']);
+        self::assertSame([10, 11], array_column($day['reservations'], 'id'));
+        self::assertSame('Alice Example', $day['reservations'][0]['customer']['name']);
+        self::assertSame('guest@example.test', $day['reservations'][1]['customer']['name']);
+
+        self::assertCount(3, $data['tables']);
+        self::assertSame([7, 9, 12], array_column($data['tables'], 'id'));
+        self::assertSame('Sala Principale', $data['tables'][0]['room_name']);
+
+        self::assertCount(2, $data['rooms']);
+        self::assertSame('Sala Privata', $data['rooms'][1]['name']);
+        self::assertSame('interni', $data['groups'][0]['code']);
+        self::assertSame([7, 9], $data['groups'][0]['tables']);
+
+        self::assertIsString($data['meta']['generated_at']);
+        self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T/', $data['meta']['generated_at']);
+    }
+
+    public function testHandleAgendaFallsBackToTodayForInvalidParameters(): void
+    {
+        $wpdb = new FakeWpdb();
+        $reservationsRepository = new ReservationsRepository($wpdb);
+        $tablesRepository       = new TablesRepository($wpdb);
+        $layout                 = new LayoutService($tablesRepository);
+
+        $service = $this->createStub(Service::class);
+
+        $today = gmdate('Y-m-d');
+
+        $rest = new AdminREST($reservationsRepository, $service, null, $layout);
+
+        $request = new WP_REST_Request([
+            'date' => 'not-a-date',
+            'range' => 'month',
+        ]);
+
+        $response = $rest->handleAgenda($request);
+        $data = $response->get_data();
+
+        self::assertSame('day', $data['range']['mode']);
+        self::assertSame($today, $data['range']['start']);
+        self::assertSame($today, $data['range']['end']);
+        self::assertSame([], $data['reservations']);
+        self::assertSame([], $data['days']);
+        self::assertSame([], $data['tables']);
+        self::assertSame([], $data['rooms']);
+        self::assertSame([], $data['groups']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,6 +16,15 @@ spl_autoload_register(static function (string $class) use ($rootDir): void {
     }
 });
 
+if (!class_exists('wpdb')) {
+    class wpdb
+    {
+        public string $prefix = 'wp_';
+        public int $insert_id = 0;
+        public string $last_error = '';
+    }
+}
+
 require_once __DIR__ . '/Support/FakeWpdb.php';
 
 if (!defined('ARRAY_A')) {
@@ -104,6 +113,16 @@ function esc_url_raw(string $url): string
 function esc_html(string $text): string
 {
     return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+function esc_attr(string $text): string
+{
+    return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+function esc_url(string $url): string
+{
+    return filter_var($url, FILTER_SANITIZE_URL) ?: '';
 }
 
 function esc_html__(string $text, string $domain = 'default'): string


### PR DESCRIPTION
## Summary
- extend the FakeWpdb test double so agenda queries can hydrate customer, table, and room metadata and respect ordering
- add unit tests for the admin agenda REST handler to verify day/week responses and fallback handling for invalid inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd7bc48670832fa3cb97cad0837868