### PR TITLE
Add fallback for missing mbstring extension

### DIFF
--- a/src/Core/Helpers.php
+++ b/src/Core/Helpers.php
@@ -9,6 +9,8 @@ use function ctype_digit;
 use function explode;
 use function filter_var;
 use function preg_match;
+use function function_exists;
+use function mb_substr;
 use function str_contains;
 use function stripos;
 use function strlen;
@@ -42,6 +44,21 @@ final class Helpers
     public static function pluginUrl(): string
     {
         return Plugin::$url;
+    }
+
+    public static function substr(string $string, int $start, ?int $length = null): string
+    {
+        if (function_exists('mb_substr')) {
+            return $length === null
+                ? mb_substr($string, $start)
+                : mb_substr($string, $start, $length);
+        }
+
+        $result = $length === null
+            ? substr($string, $start)
+            : substr($string, $start, $length);
+
+        return $result === false ? '' : $result;
     }
 
     public static function clientIp(): string

--- a/src/Core/Mailer.php
+++ b/src/Core/Mailer.php
@@ -12,7 +12,6 @@ use function file_exists;
 use function file_put_contents;
 use function function_exists;
 use function is_array;
-use function mb_substr;
 use function preg_split;
 use function rename;
 use function sanitize_file_name;
@@ -192,7 +191,7 @@ class Mailer
         $stripped = trim(wp_strip_all_tags($message));
         $line     = preg_split('/\r?\n/', $stripped, 2)[0] ?? '';
 
-        return mb_substr($line, 0, 191);
+        return Helpers::substr($line, 0, 191);
     }
 
     /**

--- a/src/Domain/Diagnostics/Service.php
+++ b/src/Domain/Diagnostics/Service.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Resv\Domain\Diagnostics;
 
 use DateTimeImmutable;
+use FP\Resv\Core\Helpers;
 use FP\Resv\Domain\Payments\Repository as PaymentsRepository;
 use FP\Resv\Domain\Reservations\Repository as ReservationsRepository;
 use wpdb;
@@ -23,7 +24,6 @@ use function is_string;
 use function json_decode;
 use function json_encode;
 use function ksort;
-use function mb_substr;
 use function number_format;
 use function rewind;
 use function sprintf;
@@ -475,9 +475,9 @@ final class Service
                 if (isset($row['meta_json']) && is_string($row['meta_json']) && $row['meta_json'] !== '') {
                     $decoded = json_decode($row['meta_json'], true);
                     if (is_array($decoded)) {
-                        $meta = mb_substr(json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), 0, 180);
+                        $meta = Helpers::substr(json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), 0, 180);
                     } else {
-                        $meta = mb_substr($row['meta_json'], 0, 180);
+                        $meta = Helpers::substr($row['meta_json'], 0, 180);
                     }
                 }
 
@@ -592,9 +592,9 @@ final class Service
                 if (is_string($payload) && $payload !== '') {
                     $decoded = json_decode($payload, true);
                     if (is_array($decoded)) {
-                        $details = mb_substr(json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), 0, 180);
+                        $details = Helpers::substr(json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), 0, 180);
                     } else {
-                        $details = mb_substr($payload, 0, 180);
+                        $details = Helpers::substr($payload, 0, 180);
                     }
                 }
 
@@ -834,9 +834,9 @@ final class Service
                 if (is_string($payload) && $payload !== '') {
                     $decoded = json_decode($payload, true);
                     if (is_array($decoded)) {
-                        $summary = mb_substr(json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), 0, 180);
+                        $summary = Helpers::substr(json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), 0, 180);
                     } else {
-                        $summary = mb_substr($payload, 0, 180);
+                        $summary = Helpers::substr($payload, 0, 180);
                     }
                 }
 
@@ -908,9 +908,9 @@ final class Service
                 if (is_string($payload) && $payload !== '') {
                     $decoded = json_decode($payload, true);
                     if (is_array($decoded)) {
-                        $summary = mb_substr(json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), 0, 180);
+                        $summary = Helpers::substr(json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), 0, 180);
                     } else {
-                        $summary = mb_substr($payload, 0, 180);
+                        $summary = Helpers::substr($payload, 0, 180);
                     }
                 }
 


### PR DESCRIPTION
## Summary
- add a helper that provides a safe substring implementation when the mbstring extension is not available
- update the mailer and diagnostics services to rely on the helper instead of calling mb_substr directly

## Testing
- php -l src/Core/Helpers.php
- php -l src/Core/Mailer.php
- php -l src/Domain/Diagnostics/Service.php

------
https://chatgpt.com/codex/tasks/task_e_68de33035738832fa00388d66d622c11