### PR TITLE
fix: guard logging hook dispatch when WordPress functions are unavailable

### DIFF
--- a/src/Core/Logging.php
+++ b/src/Core/Logging.php
@@ -4,11 +4,22 @@ declare(strict_types=1);
 
 namespace FP\Resv\Core;
 
+use function do_action;
+use function error_log;
+use function function_exists;
+use function sprintf;
+
 final class Logging
 {
     public static function log(string $channel, string $message, array $context = []): void
     {
         // @todo Implement logging strategy (database tables / WP logger).
+        if (!function_exists('do_action')) {
+            error_log(sprintf('[fp-resv][%s] %s', $channel, $message));
+
+            return;
+        }
+
         do_action('fp_resv_log', $channel, $message, $context);
     }
 }


### PR DESCRIPTION
## Summary
- add safety checks in the logging helper to avoid calling WordPress hooks when they are not loaded yet
- fall back to a simple error_log message so plugin initialization no longer fatals in minimal environments

## Testing
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68de354ff2e0832faa5daa21db8ade23