### PR TITLE
Respect consent before persisting attribution cookie

### DIFF
--- a/src/Domain/Tracking/Manager.php
+++ b/src/Domain/Tracking/Manager.php
@@ -99,7 +99,7 @@ final class Manager
             return;
         }
 
-        if (!Consent::has('ads')) {
+        if (!Consent::has('ads') && !Consent::has('analytics')) {
             return;
         }
 

--- a/tests/Unit/Domain/Tracking/ManagerTest.php
+++ b/tests/Unit/Domain/Tracking/ManagerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\Resv\Tests\Unit\Domain\Tracking;
+
+use FP\Resv\Core\Consent;
+use FP\Resv\Domain\Settings\Options;
+use FP\Resv\Domain\Tracking\Ads;
+use FP\Resv\Domain\Tracking\Clarity;
+use FP\Resv\Domain\Tracking\GA4;
+use FP\Resv\Domain\Tracking\Manager;
+use FP\Resv\Domain\Tracking\Meta;
+use PHPUnit\Framework\TestCase;
+
+final class ManagerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        unset($_COOKIE['fp_resv_utm']);
+        $_GET = [];
+        $GLOBALS['__wp_tests_options'] = [];
+    }
+
+    public function testCaptureAttributionSkipsWhenConsentDenied(): void
+    {
+        $this->bootstrapConsent(['consent_mode_default' => 'denied']);
+        $_GET['utm_source'] = 'newsletter';
+
+        $manager = $this->createManager();
+        $manager->captureAttribution();
+
+        self::assertArrayNotHasKey('fp_resv_utm', $_COOKIE);
+    }
+
+    public function testCaptureAttributionStoresWhenAnalyticsConsentGranted(): void
+    {
+        $this->bootstrapConsent(['consent_mode_default' => 'denied']);
+        Consent::update(['analytics' => 'granted']);
+        $_GET['utm_source'] = 'google';
+
+        $manager = $this->createManager();
+        $manager->captureAttribution();
+
+        self::assertArrayHasKey('fp_resv_utm', $_COOKIE);
+        $data = json_decode((string) $_COOKIE['fp_resv_utm'], true);
+        self::assertIsArray($data);
+        self::assertSame('google', $data['utm_source'] ?? null);
+    }
+
+    public function testCaptureAttributionStoresWhenAdsConsentGranted(): void
+    {
+        $this->bootstrapConsent(['consent_mode_default' => 'denied']);
+        Consent::update(['ads' => 'granted']);
+        $_GET['utm_medium'] = 'cpc';
+
+        $manager = $this->createManager();
+        $manager->captureAttribution();
+
+        self::assertArrayHasKey('fp_resv_utm', $_COOKIE);
+        $data = json_decode((string) $_COOKIE['fp_resv_utm'], true);
+        self::assertIsArray($data);
+        self::assertSame('cpc', $data['utm_medium'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $tracking
+     */
+    private function bootstrapConsent(array $tracking = []): void
+    {
+        $GLOBALS['__wp_tests_options']['fp_resv_tracking'] = $tracking;
+        Consent::init(new Options());
+    }
+
+    private function createManager(): Manager
+    {
+        $options = new Options();
+        $ga4     = new GA4($options);
+        $ads     = new Ads($options);
+        $meta    = new Meta($options);
+        $clarity = new Clarity($options);
+
+        return new Manager($options, $ga4, $ads, $meta, $clarity);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -360,3 +360,24 @@ if (!function_exists('pll_current_language')) {
     }
 }
 
+if (!function_exists('wp_unslash')) {
+    function wp_unslash(string $value): string
+    {
+        return stripslashes($value);
+    }
+}
+
+if (!function_exists('is_admin')) {
+    function is_admin(): bool
+    {
+        return false;
+    }
+}
+
+if (!function_exists('is_ssl')) {
+    function is_ssl(): bool
+    {
+        return false;
+    }
+}
+


### PR DESCRIPTION
## Summary
- gate UTM attribution storage so it only runs when analytics or ads consent was granted
- add PHPUnit coverage for the tracking manager consent checks
- extend the test bootstrap with WordPress helper stubs needed by the new tests

## Testing
- `vendor/bin/phpunit -c tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68de38e168b8832fa5cdeaf2fbaa1b44