### PR TITLE
Improve logging fallback context handling

### DIFF
--- a/src/Core/Logging.php
+++ b/src/Core/Logging.php
@@ -7,19 +7,72 @@ namespace FP\Resv\Core;
 use function do_action;
 use function error_log;
 use function function_exists;
+use function has_action;
+use function is_string;
+use function json_encode;
+use function preg_replace;
 use function sprintf;
+use function trim;
+use function var_export;
+use function wp_json_encode;
+use const JSON_PARTIAL_OUTPUT_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
 
 final class Logging
 {
     public static function log(string $channel, string $message, array $context = []): void
     {
-        // @todo Implement logging strategy (database tables / WP logger).
-        if (!function_exists('do_action')) {
-            error_log(sprintf('[fp-resv][%s] %s', $channel, $message));
+        $dispatched = false;
 
+        if (function_exists('do_action')) {
+            do_action('fp_resv_log', $channel, $message, $context);
+
+            $hasListeners = function_exists('has_action')
+                ? has_action('fp_resv_log') !== false
+                : false;
+
+            $dispatched = $hasListeners;
+        }
+
+        if ($dispatched) {
             return;
         }
 
-        do_action('fp_resv_log', $channel, $message, $context);
+        error_log(sprintf('[fp-resv][%s] %s%s', $channel, $message, self::formatContext($context)));
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private static function formatContext(array $context): string
+    {
+        if ($context === []) {
+            return '';
+        }
+
+        $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR;
+        $encoded = null;
+
+        if (function_exists('wp_json_encode')) {
+            $encoded = wp_json_encode($context, $options);
+        }
+
+        if (!is_string($encoded) || $encoded === '') {
+            $encoded = json_encode($context, $options);
+        }
+
+        if (is_string($encoded) && $encoded !== '' && $encoded !== '[]' && $encoded !== '{}') {
+            return ' ' . $encoded;
+        }
+
+        $fallback = var_export($context, true);
+        $normalized = preg_replace('/\s+/', ' ', trim($fallback));
+
+        if (!is_string($normalized) || $normalized === '') {
+            return '';
+        }
+
+        return ' ' . $normalized;
     }
 }

--- a/tests/Unit/Core/LoggingTest.php
+++ b/tests/Unit/Core/LoggingTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\Resv\Tests\Unit\Core;
+
+use FP\Resv\Core\Logging;
+use PHPUnit\Framework\TestCase;
+
+use function add_action;
+use function file_get_contents;
+use function ini_set;
+use function is_file;
+use function sprintf;
+use function strpos;
+use function sys_get_temp_dir;
+use function tempnam;
+use function trim;
+
+final class LoggingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        unset($GLOBALS['__wp_tests_hooks']['fp_resv_log']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['__wp_tests_hooks']['fp_resv_log']);
+        parent::tearDown();
+    }
+
+    public function testLogsToErrorLogWhenNoHandlersAreRegistered(): void
+    {
+        $logFile  = tempnam(sys_get_temp_dir(), 'fp-resv-log-') ?: sys_get_temp_dir() . '/fp-resv-log';
+        $previous = ini_set('error_log', $logFile);
+
+        Logging::log('reservations', 'Test message', ['foo' => 'bar']);
+
+        $output = is_file($logFile) ? (file_get_contents($logFile) ?: '') : '';
+        @unlink($logFile);
+
+        if ($previous !== false) {
+            ini_set('error_log', $previous);
+        }
+
+        $this->assertNotFalse(strpos($output, '[fp-resv][reservations] Test message'));
+        $this->assertNotFalse(strpos($output, '"foo":"bar"'));
+    }
+
+    public function testLogsContextEvenWhenEncodingFails(): void
+    {
+        $logFile  = tempnam(sys_get_temp_dir(), 'fp-resv-log-') ?: sys_get_temp_dir() . '/fp-resv-log';
+        $previous = ini_set('error_log', $logFile);
+
+        Logging::log('reservations', 'Broken context', ['bad' => "\xC3\x28"]);
+
+        $output = is_file($logFile) ? (file_get_contents($logFile) ?: '') : '';
+        @unlink($logFile);
+
+        if ($previous !== false) {
+            ini_set('error_log', $previous);
+        }
+
+        $this->assertNotFalse(strpos($output, '[fp-resv][reservations] Broken context'));
+        $this->assertNotFalse(strpos($output, '"bad":null'));
+    }
+
+    public function testSkipsFallbackWhenListenerIsRegistered(): void
+    {
+        $captured = '';
+        add_action('fp_resv_log', function (string $channel, string $message, array $context) use (&$captured): void {
+            $captured = sprintf('%s:%s', $channel, $message);
+        }, 10, 3);
+
+        $logFile  = tempnam(sys_get_temp_dir(), 'fp-resv-log-') ?: sys_get_temp_dir() . '/fp-resv-log';
+        $previous = ini_set('error_log', $logFile);
+
+        Logging::log('mail', 'Handled');
+
+        $output = is_file($logFile) ? (file_get_contents($logFile) ?: '') : '';
+        @unlink($logFile);
+
+        if ($previous !== false) {
+            ini_set('error_log', $previous);
+        }
+
+        $this->assertSame('mail:Handled', $captured);
+        $this->assertSame('', trim($output));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the logging fallback uses a formatter that prefers wp_json_encode/json_encode with partial output and falls back to a normalized export
- update the WordPress test stub to accept wp_json_encode options/depth so behaviour mirrors production
- add unit coverage proving the error log still includes context data even when encoding fails

## Testing
- vendor/bin/phpunit -c tests/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68de431f0894832f9ddbc0f7f73bdaf0