### PR TITLE
fix: guard plugin version constant

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -59,6 +59,11 @@ use function is_admin;
 
 final class Plugin
 {
+    /**
+     * Current plugin semantic version.
+     *
+     * Keep this in sync with the plugin header in fp-restaurant-reservations.php.
+     */
     public const VERSION = '0.1.1';
 
     public static string $file;

--- a/tests/Unit/Core/PluginVersionTest.php
+++ b/tests/Unit/Core/PluginVersionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\Resv\Tests\Unit\Core;
+
+use FP\Resv\Core\Plugin;
+use PHPUnit\Framework\TestCase;
+
+final class PluginVersionTest extends TestCase
+{
+    public function testVersionConstantMatchesPluginHeader(): void
+    {
+        $pluginFile = dirname(__DIR__, 3) . '/fp-restaurant-reservations.php';
+        $contents   = file_get_contents($pluginFile);
+
+        $this->assertNotFalse($contents, 'Plugin file should be readable.');
+
+        $matches = [];
+        $this->assertSame(1, preg_match('/^\s*\*\s*Version:\s*(?<version>[^\r\n]+)/m', $contents, $matches));
+        $this->assertArrayHasKey('version', $matches);
+
+        $headerVersion = trim($matches['version']);
+
+        $this->assertSame(
+            $headerVersion,
+            Plugin::VERSION,
+            'The plugin header and Plugin::VERSION must remain in sync.'
+        );
+    }
+
+    public function testVersionConstantIsSemantic(): void
+    {
+        $this->assertSame(
+            1,
+            preg_match('/^\d+\.\d+\.\d+$/', Plugin::VERSION),
+            'Plugin::VERSION must be a semantic version string (X.Y.Z).'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- document the Plugin::VERSION constant to keep it aligned with the plugin header
- add unit coverage that enforces the semantic format and header sync for Plugin::VERSION

## Testing
- vendor/bin/phpunit -c tests/phpunit.xml tests/Unit/Core/PluginVersionTest.php

------
https://chatgpt.com/codex/tasks/task_e_68deafac2764832f88b54a1b9ea29514