### PR TITLE
Fix version constant visibility for broader PHP compatibility

### DIFF
--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -64,7 +64,7 @@ final class Plugin
      *
      * Keep this in sync with the plugin header in fp-restaurant-reservations.php.
      */
-    public const VERSION = '0.1.1';
+    const VERSION = '0.1.1';
 
     /**
      * @var string|null

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -64,6 +64,7 @@ final class Plugin
      *
      * Keep this in sync with the plugin header in fp-restaurant-reservations.php.
      */
+    // Intentionally omit visibility for compatibility with PHP < 7.1 (which does not support constant visibility).
     const VERSION = '0.1.1';
 
     /**


### PR DESCRIPTION
## Summary
- remove the visibility modifier from the plugin version constant so the file parses on PHP versions that do not support public constants

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec628aa4c832f993022cf74f5d117