### PR TITLE
Fix bump-version script regex for VERSION constant

### DIFF
--- a/tools/bump-version.php
+++ b/tools/bump-version.php
@@ -110,7 +110,7 @@ if (is_file($pluginClass)) {
         exit(1);
     }
 
-    $versionConstPattern = '/((?:(?:public|protected|private)\s+)?const\s+VERSION\s*=\s*)([\'\"])(?:[^\'"\n\r]+)([\'\"])(\s*;)/m';
+    $versionConstPattern = '/((?:(?:public|protected|private)\s+)?const\s+VERSION\s*=\s*)([\'\"])(?:[^\'"\n\r]+)(\2)(\s*;)/m';
 
     $versionUpdated = preg_replace_callback(
         $versionConstPattern,

--- a/tools/bump-version.php
+++ b/tools/bump-version.php
@@ -110,8 +110,17 @@ if (is_file($pluginClass)) {
         exit(1);
     }
 
-    $versionConstPattern = '/(public\s+const\s+VERSION\s*=\s*\')(?:[^\']+)(\';)/';
-    $versionUpdated      = preg_replace($versionConstPattern, '$1' . $newVersion . '$2', $pluginClassContents, 1, $constCount);
+    $versionConstPattern = '/((?:(?:public|protected|private)\s+)?const\s+VERSION\s*=\s*)([\'\"])(?:[^\'"\n\r]+)([\'\"])(\s*;)/m';
+
+    $versionUpdated = preg_replace_callback(
+        $versionConstPattern,
+        static function (array $match) use ($newVersion): string {
+            return $match[1] . $match[2] . $newVersion . $match[3] . $match[4];
+        },
+        $pluginClassContents,
+        1,
+        $constCount
+    );
 
     if ($versionUpdated === null || $constCount === 0) {
         fwrite(STDERR, "Failed to update Plugin::VERSION constant.\n");


### PR DESCRIPTION
## Summary
- broaden the bump-version regex so it matches constants with or without visibility modifiers
- preserve the original quoting and spacing when rewriting the Plugin::VERSION constant

## Testing
- php tools/bump-version.php --set=0.1.1

------
https://chatgpt.com/codex/tasks/task_e_68dec77ccc04832fa978da29b9bd6903