### PR TITLE
Sync inline field and slot styles with stylesheet

### DIFF
--- a/assets/css/form.css
+++ b/assets/css/form.css
@@ -149,6 +149,8 @@
     border-radius: calc(var(--fp-resv-radius-lg) * 0.9);
     border: 1px solid rgba(148, 163, 184, 0.22);
     box-shadow: 0 22px 45px -32px rgba(15, 23, 42, 0.45);
+    box-sizing: border-box;
+    width: 100%;
 }
 
 .fp-progress {
@@ -163,6 +165,7 @@
     padding: clamp(0.1rem, 0.45vw, 0.25rem) clamp(0.35rem, 1.6vw, 0.65rem);
     margin: 0;
     position: relative;
+    isolation: isolate;
     counter-reset: fp-progress;
     overflow-x: auto;
     scroll-snap-type: x mandatory;
@@ -200,6 +203,7 @@
     );
     border-radius: 999px;
     pointer-events: none;
+    z-index: 0;
 }
 
 .fp-progress::after {
@@ -221,6 +225,7 @@
     transition: width 220ms ease;
     pointer-events: none;
     box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.04);
+    z-index: 0;
 }
 
 .fp-progress__item {
@@ -253,6 +258,7 @@
     transition: background 220ms ease, color 220ms ease, border-color 220ms ease, transform 200ms ease, box-shadow 220ms ease,
         padding-inline 220ms ease, min-width 220ms ease;
     isolation: isolate;
+    z-index: 1;
 }
 
 .fp-progress__item::before {
@@ -648,42 +654,48 @@
 .fp-resv-field--consent {
     display: flex;
     flex-direction: row;
-    align-items: flex-start;
-    gap: 0.75rem;
+    align-items: center;
+    gap: 0.65rem;
 }
 
 .fp-resv-field--consent .fp-checkbox {
     flex: 0 0 auto;
-    margin-top: 0.35rem;
+    margin-top: 0;
 }
 
 .fp-resv-consent__text {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.45rem;
+    flex-wrap: wrap;
     min-width: 0;
 }
 
 .fp-resv-consent__copy {
     line-height: 1.5;
+    flex: 1 1 auto;
 }
 
 .fp-resv-consent__meta {
-    align-self: flex-start;
+    flex: 0 0 auto;
     border-radius: 999px;
-    font-size: 0.7rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    line-height: 1;
-    padding: 0.2rem 0.65rem 0.25rem;
+    font-size: 0.65rem;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    line-height: 1.1;
+    padding: 0.18rem 0.55rem 0.22rem;
     text-transform: uppercase;
-    background: rgba(var(--fp-resv-color-muted-rgb, 100, 116, 139), 0.12);
+    background: rgba(var(--fp-resv-color-muted-rgb, 100, 116, 139), 0.08);
     color: var(--fp-resv-color-muted);
+    border: 1px solid rgba(var(--fp-resv-color-muted-rgb, 100, 116, 139), 0.18);
 }
 
 .fp-resv-consent__meta--required {
-    background: rgba(var(--fp-resv-color-primary-rgb, 59, 130, 246), 0.15);
+    background: rgba(var(--fp-resv-color-primary-rgb, 59, 130, 246), 0.12);
+    border-color: rgba(var(--fp-resv-color-primary-rgb, 59, 130, 246), 0.2);
     color: var(--fp-resv-color-primary);
+    font-weight: 600;
 }
 
 .fp-resv-consent__text a {
@@ -693,7 +705,7 @@
 
 @media (min-width: 960px) {
     .fp-resv-fields--grid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 
@@ -714,17 +726,23 @@
     flex-direction: row-reverse;
     align-items: stretch;
     gap: 0.65rem;
+    flex-wrap: wrap;
 }
 
 .fp-resv-phone-input .fp-input {
     min-height: 48px;
+    flex: 1 1 12rem;
+    min-width: 0;
+    width: auto;
 }
 
 .fp-resv-phone-input .fp-input--prefix {
-    max-width: 8rem;
-    text-align: center;
-    padding-inline: 0.65rem;
     flex: 0 0 auto;
+    width: 8rem;
+    width: clamp(5.5rem, 32vw, 8rem);
+    max-width: 100%;
+    text-align: left;
+    padding-inline: 0.65rem;
 }
 
 .fp-resv-phone-input__static {
@@ -1062,9 +1080,33 @@
 }
 
 .fp-meals__notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
     margin: clamp(2rem, 5vw, 2.75rem) 0 0;
     font-size: 0.92em;
     color: var(--fp-resv-color-primary);
+}
+
+.fp-meals__notice-text {
+    font-style: italic;
+}
+
+.fp-meals__notice-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 1.75em;
+    height: 1.75em;
+    margin-top: 0.1em;
+    border-radius: 999px;
+    background-color: currentColor;
+    color: var(--fp-resv-color-surface);
+    font-style: normal;
+    font-weight: 600;
+    font-size: 0.75em;
+    line-height: 1;
 }
 
 .fp-resv-step__header {
@@ -1271,9 +1313,9 @@
         gap: 0.45rem;
         overflow-x: auto;
         overflow-y: hidden;
-        padding: 0.25rem 0.2rem 0.35rem;
+        padding: 0.25rem 0.35rem 0.35rem;
         scroll-snap-type: x proximity;
-        scroll-padding-inline: 0.2rem;
+        scroll-padding-inline: 0.35rem;
     }
 
     .fp-progress::before,

--- a/src/Domain/Settings/Language.php
+++ b/src/Domain/Settings/Language.php
@@ -441,6 +441,7 @@ final class Language
                         'msg_invalid_email'   => 'Inserisci un indirizzo email valido.',
                         'msg_submit_error'    => 'Non è stato possibile completare la prenotazione. Riprova.',
                         'msg_submit_success'  => 'Prenotazione inviata con successo.',
+                        'meal_full_notice'    => 'Nessuna disponibilità per questo servizio. Scegli un altro giorno.',
                     ],
                     'consents_meta' => [
                         'required' => 'Obbligatorio',
@@ -650,6 +651,7 @@ final class Language
                         'msg_invalid_email'   => 'Enter a valid email address.',
                         'msg_submit_error'    => 'We could not complete your reservation. Please try again.',
                         'msg_submit_success'  => 'Reservation sent successfully.',
+                        'meal_full_notice'    => 'No availability for this service. Please choose another day.',
                     ],
                     'consents_meta' => [
                         'required' => 'Required',

--- a/src/Domain/Settings/Style.php
+++ b/src/Domain/Settings/Style.php
@@ -308,6 +308,11 @@ final class Style
         $lines[] = '    --fp-resv-heading-weight: ' . $headingWeight . ';';
         $lines[] = '    --fp-resv-radius: ' . $radius . 'px;';
         $lines[] = '    --fp-resv-shadow: ' . $shadow . ';';
+        $lines[] = '    --fp-resv-radius-lg: calc(var(--fp-resv-radius) * 1.05);';
+        $lines[] = '    --fp-resv-radius-md: var(--fp-resv-radius);';
+        $lines[] = '    --fp-resv-radius-sm: calc(var(--fp-resv-radius) * 0.55);';
+        $lines[] = '    --fp-resv-shadow-lg: var(--fp-resv-shadow);';
+        $lines[] = '    --fp-resv-shadow-sm: 0 12px 30px rgba(15, 23, 42, 0.08);';
         $lines[] = '    --fp-resv-space-unit: ' . $spacingUnit . ';';
         $lines[] = '    --fp-resv-space-xxs: calc(var(--fp-resv-space-unit) * 0.35);';
         $lines[] = '    --fp-resv-space-xs: calc(var(--fp-resv-space-unit) * 0.6);';
@@ -315,7 +320,15 @@ final class Style
         $lines[] = '    --fp-resv-space-md: calc(var(--fp-resv-space-unit) * 1);';
         $lines[] = '    --fp-resv-space-lg: calc(var(--fp-resv-space-unit) * 1.6);';
         $lines[] = '    --fp-resv-space-xl: calc(var(--fp-resv-space-unit) * 2.4);';
+        $lines[] = '    --fp-resv-spacing-xs: var(--fp-resv-space-sm);';
+        $lines[] = '    --fp-resv-spacing-sm: var(--fp-resv-space-md);';
+        $lines[] = '    --fp-resv-spacing-md: var(--fp-resv-space-lg);';
+        $lines[] = '    --fp-resv-spacing-lg: var(--fp-resv-space-xl);';
+        $lines[] = '    --fp-resv-spacing-xl: calc(var(--fp-resv-space-xl) * 1.25);';
+        [$primaryRed, $primaryGreen, $primaryBlue] = $this->hexToRgb($tokens['primary']);
+
         $lines[] = '    --fp-resv-focus-ring-width: ' . $focusWidth . 'px;';
+        $lines[] = '    --fp-resv-focus-ring: 0 0 0 var(--fp-resv-focus-ring-width, 3px) var(--fp-resv-focus);';
         $lines[] = '    --fp-resv-primary: ' . $tokens['primary'] . ';';
         $lines[] = '    --fp-resv-on-primary: ' . $tokens['on_primary'] . ';';
         $lines[] = '    --fp-resv-primary-soft: ' . $tokens['primary_soft'] . ';';
@@ -340,6 +353,19 @@ final class Style
         $lines[] = '    --fp-resv-success-text: ' . $tokens['success_text'] . ';';
         $lines[] = '    --fp-resv-danger: ' . $tokens['danger'] . ';';
         $lines[] = '    --fp-resv-danger-text: ' . $tokens['danger_text'] . ';';
+        $lines[] = '    --fp-resv-color-surface: ' . $tokens['surface'] . ';';
+        $lines[] = '    --fp-resv-color-surface-alt: ' . $tokens['surface_alt'] . ';';
+        $lines[] = '    --fp-resv-color-text: ' . $tokens['text'] . ';';
+        $lines[] = '    --fp-resv-color-muted: ' . $tokens['muted'] . ';';
+        $lines[] = '    --fp-resv-color-border: ' . $tokens['outline'] . ';';
+        $lines[] = '    --fp-resv-color-primary: ' . $tokens['primary'] . ';';
+        $lines[] = '    --fp-resv-color-primary-strong: ' . $tokens['primary'] . ';';
+        $lines[] = '    --fp-resv-color-primary-soft: ' . $tokens['primary_soft'] . ';';
+        $lines[] = '    --fp-resv-color-primary-contrast: ' . $tokens['on_primary'] . ';';
+        $lines[] = '    --fp-resv-color-success: ' . $tokens['success'] . ';';
+        $lines[] = '    --fp-resv-color-error: ' . $tokens['danger'] . ';';
+        $lines[] = '    --fp-resv-color-warning: ' . $tokens['accent'] . ';';
+        $lines[] = sprintf('    --fp-resv-color-primary-rgb: %d, %d, %d;', $primaryRed, $primaryGreen, $primaryBlue);
         $lines[] = '}';
 
         return implode("\n", $lines) . "\n";
@@ -400,6 +426,225 @@ final class Style
     gap: 1rem;
     padding-bottom: 1rem;
     border-bottom: 1px solid var(--fp-resv-divider);
+}
+%s .fp-resv-progress {
+    box-sizing: border-box;
+    width: 100%;
+}
+%s .fp-progress {
+    --fp-progress-height: 6px;
+    --fp-progress-fill: 0%;
+    --fp-progress-gap: clamp(0.55rem, 1.4vw, 0.95rem);
+    list-style: none;
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: var(--fp-progress-gap);
+    padding: clamp(0.1rem, 0.45vw, 0.25rem) clamp(0.35rem, 1.6vw, 0.65rem);
+    margin: 0;
+    position: relative;
+    isolation: isolate;
+    counter-reset: fp-progress;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.35) transparent;
+    -webkit-overflow-scrolling: touch;
+}
+%s .fp-progress::-webkit-scrollbar {
+    height: 0.35rem;
+}
+%s .fp-progress::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.35);
+    border-radius: 999px;
+}
+%s .fp-progress::-webkit-scrollbar-track {
+    background: transparent;
+}
+%s .fp-progress::before {
+    content: '';
+    position: absolute;
+    inset-inline: 0;
+    top: 50%;
+    height: var(--fp-progress-height);
+    transform: translateY(-50%);
+    background: linear-gradient(
+        90deg,
+        transparent,
+        rgba(148, 163, 184, 0.38) 16%,
+        rgba(148, 163, 184, 0.38) 84%,
+        transparent
+    );
+    border-radius: 999px;
+    pointer-events: none;
+    z-index: 0;
+}
+%s .fp-progress::after {
+    content: '';
+    position: absolute;
+    inset-inline-start: 0;
+    top: 50%;
+    height: var(--fp-progress-height);
+    transform: translateY(-50%);
+    width: var(--fp-progress-fill);
+    background: linear-gradient(
+        90deg,
+        transparent,
+        var(--fp-resv-color-primary) 12%,
+        var(--fp-resv-color-primary-strong) 88%,
+        transparent
+    );
+    border-radius: 999px;
+    transition: width 220ms ease;
+    pointer-events: none;
+    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.04);
+    z-index: 0;
+}
+%s .fp-progress__item {
+    --fp-progress-item-padding-inline: clamp(0.45rem, 1.35vw, 0.85rem);
+    --fp-progress-item-padding-block: clamp(0.4rem, 1.2vw, 0.7rem);
+    --fp-progress-item-min-width: clamp(2.45rem, 2.95vw, 2.9rem);
+    --fp-progress-label-gap: 0;
+    --fp-progress-label-max-width: 0;
+    --fp-progress-label-opacity: 0;
+    --fp-progress-label-translate: -0.25rem;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--fp-progress-label-gap);
+    padding-inline: var(--fp-progress-item-padding-inline);
+    padding-block: var(--fp-progress-item-padding-block);
+    background: rgba(255, 255, 255, 0.75);
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    box-shadow: 0 12px 35px -24px rgba(15, 23, 42, 0.6);
+    color: var(--fp-resv-color-muted);
+    font-size: 0.9rem;
+    font-weight: 600;
+    line-height: 1.3;
+    text-transform: none;
+    min-width: var(--fp-progress-item-min-width);
+    flex: 0 0 auto;
+    scroll-snap-align: center;
+    transition: background 220ms ease, color 220ms ease, border-color 220ms ease, transform 200ms ease, box-shadow 220ms ease, padding-inline 220ms ease, min-width 220ms ease;
+    isolation: isolate;
+    z-index: 1;
+}
+%s .fp-progress__item::before {
+    content: '';
+    position: absolute;
+    inset: 1px;
+    border-radius: inherit;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(226, 232, 240, 0.25));
+    opacity: 0.85;
+    z-index: -1;
+    pointer-events: none;
+    transition: opacity 220ms ease;
+}
+%s .fp-progress__item:not([aria-disabled="true"]) {
+    cursor: pointer;
+}
+%s .fp-progress__item[aria-disabled="true"] {
+    cursor: default;
+    pointer-events: none;
+}
+%s .fp-progress__item:focus-visible {
+    outline: 3px solid var(--fp-resv-color-primary);
+    outline-offset: 2px;
+}
+%s .fp-progress__item::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    box-shadow: 0 18px 42px -28px rgba(15, 23, 42, 0.55);
+    opacity: 0;
+    transition: opacity 200ms ease;
+    z-index: -2;
+}
+%s .fp-progress__index {
+    position: relative;
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: clamp(2.1rem, 3vw, 2.4rem);
+    height: clamp(2.1rem, 3vw, 2.4rem);
+    border-radius: 999px;
+    border: 2px solid rgba(148, 163, 184, 0.35);
+    background: rgba(241, 245, 249, 0.85);
+    color: var(--fp-resv-color-primary);
+    font-size: 0.78em;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-feature-settings: 'tnum' 1;
+    transition: background 220ms ease, border-color 220ms ease, color 220ms ease, box-shadow 220ms ease;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+%s .fp-progress__label {
+    display: block;
+    max-width: var(--fp-progress-label-max-width);
+    opacity: var(--fp-progress-label-opacity);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: inherit;
+    letter-spacing: 0.01em;
+    transform: translateX(var(--fp-progress-label-translate));
+    transition: max-width 240ms ease, opacity 180ms ease, transform 200ms ease;
+}
+%s .fp-progress__label[aria-hidden="true"] {
+    pointer-events: none;
+}
+%s .fp-progress__item[data-state="active"],
+%s .fp-progress__item[data-progress-state="active"],
+%s .fp-progress__item:focus-visible {
+    --fp-progress-item-padding-inline: clamp(0.65rem, 1.75vw, 1.1rem);
+    --fp-progress-item-min-width: clamp(6.25rem, 16vw, 9.75rem);
+    --fp-progress-label-gap: clamp(0.4rem, 1.1vw, 0.65rem);
+    --fp-progress-label-max-width: clamp(6.25rem, 20vw, 9.75rem);
+    --fp-progress-label-opacity: 1;
+    --fp-progress-label-translate: 0;
+    justify-content: flex-start;
+    color: var(--fp-resv-color-text);
+}
+%s .fp-progress__item[data-state="active"],
+%s .fp-progress__item[data-progress-state="active"],
+%s .fp-resv-step[aria-hidden="false"] ~ .fp-progress__item,
+%s .fp-progress__item:first-child {
+    color: var(--fp-resv-color-text);
+}
+%s .fp-progress__item[data-state="active"],
+%s .fp-progress__item[data-completed="true"],
+%s .fp-progress__item[data-progress-state="done"],
+%s .fp-progress__item[data-progress-state="active"] {
+    background: linear-gradient(130deg, rgba(var(--fp-resv-color-primary-rgb, 59, 130, 246), 0.12), rgba(var(--fp-resv-color-primary-rgb, 59, 130, 246), 0.04));
+    border-color: rgba(var(--fp-resv-color-primary-rgb, 59, 130, 246), 0.35);
+    color: var(--fp-resv-color-text);
+    transform: translateY(-1px);
+}
+%s .fp-progress__item[data-state="active"]::before,
+%s .fp-progress__item[data-completed="true"]::before,
+%s .fp-progress__item[data-progress-state="done"]::before,
+%s .fp-progress__item[data-progress-state="active"]::before {
+    opacity: 1;
+}
+%s .fp-progress__item[data-state="active"]::after,
+%s .fp-progress__item[data-completed="true"]::after,
+%s .fp-progress__item[data-progress-state="done"]::after,
+%s .fp-progress__item[data-progress-state="active"]::after {
+    opacity: 1;
+}
+%s .fp-progress__item[data-state="active"] .fp-progress__index,
+%s .fp-progress__item[data-completed="true"] .fp-progress__index,
+%s .fp-progress__item[data-progress-state="done"] .fp-progress__index,
+%s .fp-progress__item[data-progress-state="active"] .fp-progress__index {
+    background: linear-gradient(135deg, var(--fp-resv-color-primary), var(--fp-resv-color-primary-strong));
+    border-color: transparent;
+    color: var(--fp-resv-color-primary-contrast);
+    box-shadow: 0 8px 18px -10px rgba(var(--fp-resv-color-primary-rgb, 59, 130, 246), 0.45);
 }
 %s .fp-resv-widget__headline {
     margin: 0;
@@ -484,58 +729,173 @@ final class Style
     gap: 0.35rem;
 }
 %s .fp-resv-field span:first-child {
-    font-size: 0.9rem;
+    font-size: 0.9em;
     font-weight: 600;
-    color: var(--fp-resv-muted);
+    color: var(--fp-resv-color-muted);
     letter-spacing: 0.01em;
 }
 %s .fp-resv-field--phone {
     grid-column: 1 / -1;
 }
+%s .fp-resv-field--phone .fp-resv-phone-input {
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: stretch;
+    gap: 0.65rem;
+    flex-wrap: wrap;
+}
+%s .fp-resv-phone-input .fp-input {
+    min-height: 48px;
+    flex: 1 1 12rem;
+    min-width: 0;
+    width: auto;
+}
+%s .fp-resv-phone-input .fp-input--prefix {
+    flex: 0 0 auto;
+    width: clamp(5.5rem, 32vw, 8rem);
+    max-width: 100%;
+    text-align: left;
+    padding-inline: 0.65rem;
+}
+%s .fp-resv-phone-input__static {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 5rem;
+    padding: 0.75rem 1rem;
+    border-radius: calc(var(--fp-resv-radius) * 0.55);
+    border: 1px solid var(--fp-resv-divider);
+    background: rgba(255, 255, 255, 0.85);
+    color: var(--fp-resv-muted);
+    font-weight: 600;
+    flex: 0 0 auto;
+}
 %s .fp-resv-field--consent {
     display: flex;
-    flex-direction: column;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
     gap: 0.65rem;
 }
 %s .fp-resv-field--consent .fp-checkbox {
-    margin-top: 0.15rem;
+    flex: 0 0 auto;
+    margin-top: 0;
 }
 %s .fp-resv-consent__text {
-    display: block;
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.45rem;
     line-height: 1.5;
+    min-width: 0;
+}
+%s .fp-resv-consent__copy {
+    flex: 1 1 auto;
+    line-height: 1.5;
+}
+%s .fp-resv-consent__meta {
+    flex: 0 0 auto;
+    border-radius: 999px;
+    font-size: 0.65rem;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    line-height: 1.1;
+    padding: 0.18rem 0.55rem 0.22rem;
+    text-transform: uppercase;
+    background: rgba(148, 163, 184, 0.08);
+    color: var(--fp-resv-muted);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+}
+%s .fp-resv-consent__meta--required {
+    background: rgba(37, 99, 235, 0.12);
+    border-color: rgba(37, 99, 235, 0.2);
+    color: var(--fp-resv-primary);
+    font-weight: 600;
 }
 %s .fp-resv-consent__text a {
     color: inherit;
     text-decoration: underline;
 }
-%s input[type="text"],
-%s input[type="email"],
-%s input[type="tel"],
-%s input[type="number"],
-%s input[type="date"],
-%s input[type="time"],
-%s textarea,
-%s select {
+%s .fp-resv-field--honeypot {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(100%);
+    border: 0;
+    white-space: nowrap;
+}
+%s .fp-resv-field--honeypot .fp-input {
+    pointer-events: none;
+}
+%s .fp-field {
+    display: grid;
+    gap: 0.35rem;
+    min-width: 0;
+}
+%s .fp-field > label {
+    display: grid;
+    gap: 0.35rem;
+}
+%s .fp-field span:first-child {
+    font-weight: 600;
+    color: var(--fp-resv-color-muted);
+    font-size: 0.9em;
+    letter-spacing: 0.01em;
+}
+%s .fp-hint {
+    font-size: 0.78em;
+    color: var(--fp-resv-color-muted);
+}
+%s .fp-input,
+%s .fp-select,
+%s .fp-textarea {
     width: 100%;
-    border-radius: calc(var(--fp-resv-radius) * 0.6);
-    border: 1px solid var(--fp-resv-divider);
-    background: rgba(255, 255, 255, 0.9);
-    color: var(--fp-resv-text);
+    border-radius: calc(var(--fp-resv-radius-lg) * 0.55);
+    border: 1px solid var(--fp-resv-divider, rgba(148, 163, 184, 0.45));
+    background: rgba(255, 255, 255, 0.85);
+    color: var(--fp-resv-color-text);
     font: inherit;
     padding: 0.75rem 1rem;
-    transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
+    transition: border 160ms ease, box-shadow 160ms ease, background 160ms ease;
+    min-height: 48px;
 }
-%s textarea {
+%s .fp-input[aria-invalid="true"],
+%s .fp-select[aria-invalid="true"],
+%s .fp-textarea[aria-invalid="true"] {
+    border-color: rgba(220, 38, 38, 0.6);
+    box-shadow: var(--fp-resv-focus-ring);
+}
+%s .fp-textarea {
     resize: vertical;
-    min-height: 4.5rem;
+    min-height: 120px;
 }
-%s input:focus-visible,
-%s textarea:focus-visible,
-%s select:focus-visible {
+%s .fp-input:focus,
+%s .fp-select:focus,
+%s .fp-textarea:focus {
+    border-color: var(--fp-resv-color-primary);
+    box-shadow: var(--fp-resv-focus-ring);
+    background: rgba(255, 255, 255, 1);
     outline: none;
-    box-shadow: 0 0 0 var(--fp-resv-focus-ring-width, 3px) var(--fp-resv-focus);
-    border-color: var(--fp-resv-focus);
+}
+%s .fp-checkbox {
+    width: 18px;
+    height: 18px;
+    border-radius: 6px;
+    border: 1.5px solid var(--fp-resv-divider, rgba(148, 163, 184, 0.6));
+    background: #fff;
+    accent-color: var(--fp-resv-color-primary);
+    transition: transform 140ms ease;
+}
+%s .fp-checkbox:focus-visible {
+    box-shadow: var(--fp-resv-focus-ring);
+    outline: none;
+}
+%s .fp-checkbox:checked {
+    transform: scale(1.05);
 }
 %s .fp-resv-fields--grid {
     display: grid;
@@ -544,7 +904,7 @@ final class Style
 }
 @media (min-width: 960px) {
     %s .fp-resv-fields--grid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     %s .fp-resv-fields--grid .fp-resv-field--email {
         grid-column: 1 / -1;
@@ -578,6 +938,11 @@ final class Style
     color: var(--fp-resv-primary);
     border-color: rgba(37, 99, 235, 0.18);
 }
+%s .fp-btn__spinner {
+    font-size: 0.95em;
+    font-weight: 500;
+    animation: fp-resv-spinner 640ms linear infinite;
+}
 %s .fp-btn:hover,
 %s .fp-btn:focus-visible,
 %s .fp-resv-button:hover,
@@ -591,6 +956,7 @@ final class Style
     justify-content: flex-end;
     gap: 0.75rem;
 }
+%s .fp-slots,
 %s .fp-resv-slots {
     display: grid;
     gap: 0.75rem;
@@ -600,12 +966,24 @@ final class Style
     background: var(--fp-resv-slot-bg);
     box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
 }
+%s .fp-slots__status,
+%s .fp-slots__empty,
 %s .fp-resv-slots__status,
 %s .fp-resv-slots__empty {
     margin: 0;
-    color: var(--fp-resv-muted);
+    color: var(--fp-resv-color-muted);
     font-size: 0.9rem;
 }
+%s .fp-slots__status[data-state="loading"],
+%s .fp-resv-slots__status[data-state="loading"] {
+    font-style: italic;
+}
+%s .fp-slots__status[data-state="error"],
+%s .fp-resv-slots__status[data-state="error"] {
+    color: var(--fp-resv-color-error);
+    font-weight: 600;
+}
+%s .fp-slots__list,
 %s .fp-resv-slots__list {
     display: grid;
     gap: 0.65rem;
@@ -614,6 +992,7 @@ final class Style
     margin: 0;
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
 }
+%s .fp-slots__list button,
 %s .fp-resv-slots__list button {
     border-radius: 999px;
     border: 1px solid var(--fp-resv-slot-border);
@@ -623,6 +1002,9 @@ final class Style
     font-size: 0.9rem;
     transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
 }
+%s .fp-slots__list button:hover,
+%s .fp-slots__list button:focus-visible,
+%s .fp-slots__list button[aria-pressed="true"],
 %s .fp-resv-slots__list button:hover,
 %s .fp-resv-slots__list button:focus-visible,
 %s .fp-resv-slots__list button[aria-pressed="true"] {
@@ -631,17 +1013,255 @@ final class Style
     background: var(--fp-resv-slot-selected-bg);
     color: var(--fp-resv-slot-selected-text);
 }
-%s .fp-resv-badge {
+%s .fp-meals {
+    border: 1px solid var(--fp-resv-divider, rgba(148, 163, 184, 0.35));
+    border-radius: calc(var(--fp-resv-radius-lg) * 0.8);
+    padding: clamp(0.85rem, 2.5vw, 1.25rem);
+    background: var(--fp-resv-color-surface-alt);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+%s .fp-meals__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 0.85rem;
+}
+%s .fp-meals__title {
+    margin: 0;
+    font-size: 1.05em;
+}
+%s .fp-meals__subtitle {
+    margin: 0;
+}
+%s .fp-meals__legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+    margin: 0 0 1rem;
+    padding: 0;
+    list-style: none;
+}
+%s .fp-meals__legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.85rem;
+    color: var(--fp-resv-color-muted, rgba(15, 23, 42, 0.75));
+}
+%s .fp-meals__legend-indicator {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 999px;
+    border: 1px solid currentColor;
+    background: currentColor;
+    opacity: 0.7;
+}
+%s .fp-meals__legend-item--available {
+    color: #16a34a;
+}
+%s .fp-meals__legend-item--limited {
+    color: #ca8a04;
+}
+%s .fp-meals__legend-item--full {
+    color: #dc2626;
+}
+%s .fp-meals__legend-text {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+%s .fp-meals__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+}
+%s .fp-meal-pill {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 0.95rem;
+    border-radius: 999px;
+    --fp-meal-pill-border: var(--fp-resv-divider, rgba(148, 163, 184, 0.4));
+    --fp-meal-pill-border-hover: var(--fp-resv-color-primary);
+    --fp-meal-pill-bg: rgba(255, 255, 255, 0.5);
+    --fp-meal-pill-text: var(--fp-resv-color-text);
+    --fp-meal-pill-highlight: linear-gradient(120deg, var(--fp-resv-color-primary-soft), rgba(14, 116, 144, 0.08));
+    --fp-meal-pill-shadow: rgba(15, 23, 42, 0.16);
+    border: 1px solid var(--fp-meal-pill-border);
+    background: var(--fp-meal-pill-bg);
+    color: var(--fp-meal-pill-text);
+    font-size: 0.92em;
+    font-weight: 500;
+    transition: border 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+    will-change: transform;
+}
+%s .fp-meal-pill::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--fp-meal-pill-highlight);
+    opacity: 0;
+    transition: opacity 180ms ease;
+    z-index: -1;
+}
+%s .fp-meal-pill[data-active],
+%s .fp-meal-pill:focus-visible,
+%s .fp-meal-pill:hover {
+    border-color: var(--fp-meal-pill-border-hover);
+    box-shadow: 0 12px 26px var(--fp-meal-pill-shadow);
+    transform: translateY(-1px);
+}
+%s .fp-meal-pill[data-active]::before,
+%s .fp-meal-pill:focus-visible::before,
+%s .fp-meal-pill:hover::before {
+    opacity: 1;
+}
+%s .fp-meal-pill[data-active] {
+    animation: fp-meal-pill-scale-in 120ms ease;
+}
+%s .fp-meal-pill__label {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
+}
+%s .fp-meal-pill[data-availability-state="available"] {
+    --fp-meal-pill-border: rgba(34, 197, 94, 0.5);
+    --fp-meal-pill-border-hover: rgba(22, 101, 52, 0.85);
+    --fp-meal-pill-bg: rgba(34, 197, 94, 0.16);
+    --fp-meal-pill-text: #166534;
+    --fp-meal-pill-highlight: linear-gradient(120deg, rgba(34, 197, 94, 0.26), rgba(21, 128, 61, 0.22));
+    --fp-meal-pill-shadow: rgba(34, 197, 94, 0.35);
+}
+%s .fp-meal-pill[data-availability-state="limited"] {
+    --fp-meal-pill-border: rgba(234, 179, 8, 0.55);
+    --fp-meal-pill-border-hover: rgba(133, 77, 14, 0.85);
+    --fp-meal-pill-bg: rgba(250, 204, 21, 0.2);
+    --fp-meal-pill-text: #854d0e;
+    --fp-meal-pill-highlight: linear-gradient(120deg, rgba(250, 204, 21, 0.28), rgba(202, 138, 4, 0.22));
+    --fp-meal-pill-shadow: rgba(250, 204, 21, 0.35);
+}
+%s .fp-meal-pill[data-availability-state="full"] {
+    --fp-meal-pill-border: rgba(248, 113, 113, 0.55);
+    --fp-meal-pill-border-hover: rgba(127, 29, 29, 0.85);
+    --fp-meal-pill-bg: rgba(248, 113, 113, 0.18);
+    --fp-meal-pill-text: #7f1d1d;
+    --fp-meal-pill-highlight: linear-gradient(120deg, rgba(248, 113, 113, 0.28), rgba(220, 38, 38, 0.24));
+    --fp-meal-pill-shadow: rgba(248, 113, 113, 0.32);
+}
+%s .fp-meals__notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin: clamp(2rem, 5vw, 2.75rem) 0 0;
+    font-size: 0.92em;
+    color: var(--fp-resv-color-primary);
+}
+%s .fp-meals__notice-text {
+    font-style: italic;
+}
+%s .fp-meals__notice-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 1.75em;
+    height: 1.75em;
+    margin-top: 0.1em;
+    border-radius: 999px;
+    background-color: currentColor;
+    color: var(--fp-resv-color-surface);
+    font-style: normal;
+    font-weight: 600;
+    font-size: 0.75em;
+    line-height: 1;
+}
+%s .fp-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
     padding: 0.1rem 0.55rem;
     border-radius: 999px;
-    font-size: 0.75rem;
+    font-size: 0.72em;
     font-weight: 600;
+    text-transform: uppercase;
     letter-spacing: 0.08em;
     background: var(--fp-resv-badge-bg, rgba(37, 99, 235, 0.12));
     color: var(--fp-resv-badge-text, var(--fp-resv-on-primary));
+}
+%s .fp-badge::before {
+    content: attr(data-icon);
+    font-size: 0.78em;
+    font-weight: 700;
+    opacity: 0.75;
+}
+%s .fp-badge:not([data-icon]),
+%s .fp-badge[data-icon=""],
+%s .fp-badge[data-icon=" "] {
+    gap: 0;
+}
+%s .fp-badge:not([data-icon])::before,
+%s .fp-badge[data-icon=""]::before,
+%s .fp-badge[data-icon=" "]::before {
+    display: none;
+}
+%s .fp-alert {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.75rem;
+    padding: clamp(0.85rem, 2vw, 1rem);
+    border-radius: calc(var(--fp-resv-radius-lg) * 0.7);
+    border: 1px solid transparent;
+    font-size: 0.95em;
+    animation: fp-resv-fade-in 240ms ease;
+}
+%s .fp-resv-widget__feedback {
+    display: grid;
+    gap: var(--fp-space-2, clamp(0.75rem, 2vw, 1rem));
+    min-width: 0;
+}
+%s .fp-resv-widget__feedback .fp-alert {
+    margin: 0;
+}
+%s .fp-alert[hidden] {
+    display: none !important;
+}
+%s .fp-alert--info {
+    background: var(--fp-resv-color-primary-soft);
+    border-color: rgba(14, 165, 233, 0.25);
+    color: var(--fp-resv-color-text);
+}
+%s .fp-alert--success {
+    background: rgba(34, 197, 94, 0.14);
+    border-color: rgba(34, 197, 94, 0.25);
+    color: var(--fp-resv-color-text);
+}
+%s .fp-alert--error {
+    background: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.35);
+    color: var(--fp-resv-color-text);
+}
+%s .fp-skeleton {
+    position: relative;
+    overflow: hidden;
+    display: inline-block;
+    width: 100%;
+    height: 14px;
+    border-radius: 8px;
+    background: linear-gradient(90deg, rgba(148, 163, 184, 0.12), rgba(148, 163, 184, 0.2), rgba(148, 163, 184, 0.12));
+}
+%s .fp-skeleton::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.6), transparent);
+    transform: translateX(-100%);
+    animation: fp-skeleton-shimmer 1200ms ease-in-out infinite;
+}
+%s .fp-resv-widget__nojs {
+    margin: 0;
 }
 %s .fp-resv-summary {
     display: grid;
@@ -678,7 +1298,66 @@ final class Style
     background: rgba(37, 99, 235, 0.12);
     color: var(--fp-resv-text);
 }
-@media (max-width: 768px) {
+@keyframes fp-resv-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+@keyframes fp-meal-pill-scale-in {
+    from {
+        transform: scale(0.96);
+        opacity: 0.75;
+    }
+    to {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+@keyframes fp-resv-spinner {
+    0% {
+        opacity: 0.4;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0.4;
+    }
+}
+@keyframes fp-skeleton-shimmer {
+    0% {
+        transform: translateX(-100%);
+    }
+    100% {
+        transform: translateX(100%);
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    %s .fp-resv,
+    %s .fp-progress__item,
+    %s .fp-meal-pill,
+    %s .fp-btn,
+    %s .fp-resv-button,
+    %s .fp-resv-step,
+    %s .fp-slots__list button,
+    %s .fp-resv-slots__list button {
+        transition: none !important;
+    }
+    %s .fp-resv,
+    %s .fp-resv-step,
+    %s .fp-alert {
+        animation: none !important;
+    }
+    %s .fp-meal-pill[data-active] {
+        animation: none !important;
+    }
+}
+@media (max-width: 960px) {
     %s .fp-resv-widget__topbar {
         flex-direction: column;
         align-items: flex-start;
@@ -688,6 +1367,81 @@ final class Style
     }
     %s .fp-resv-step__footer > * {
         flex: 1 1 auto;
+    }
+    %s .fp-progress__item {
+        --fp-progress-item-padding-inline: 0.6rem;
+        --fp-progress-item-padding-block: 0.55rem;
+        --fp-progress-item-min-width: 2.45rem;
+        font-size: 0.82em;
+    }
+    %s .fp-progress__item[data-state="active"],
+    %s .fp-progress__item[data-progress-state="active"],
+    %s .fp-progress__item:focus-visible {
+        --fp-progress-item-padding-inline: 0.68rem;
+        --fp-progress-item-min-width: 7.35rem;
+        --fp-progress-label-gap: 0.5rem;
+        --fp-progress-label-max-width: clamp(6.1rem, 34vw, 9.65rem);
+    }
+    %s .fp-progress__index {
+        width: 2rem;
+        height: 2rem;
+        font-size: 0.72em;
+        letter-spacing: 0.06em;
+    }
+}
+@media (min-width: 961px) {
+    %s .fp-progress {
+        justify-content: center;
+    }
+    %s .fp-progress__item {
+        flex: 1 1 clamp(2.6rem, 6.8vw, 9.25rem);
+        min-width: 0;
+    }
+}
+@media (max-width: 640px) {
+    %s .fp-progress {
+        gap: 0.45rem;
+        overflow-x: auto;
+        overflow-y: hidden;
+        padding: 0.25rem 0.35rem 0.35rem;
+        scroll-snap-type: x proximity;
+        scroll-padding-inline: 0.35rem;
+    }
+    %s .fp-progress::before,
+    %s .fp-progress::after {
+        display: none;
+    }
+    %s .fp-progress__item {
+        --fp-progress-item-padding-inline: 0.5rem;
+        --fp-progress-item-padding-block: 0.5rem;
+        --fp-progress-item-min-width: 2.35rem;
+        font-size: 0.78em;
+    }
+    %s .fp-progress__index {
+        width: 1.95rem;
+        height: 1.95rem;
+        font-size: 0.7em;
+    }
+    %s .fp-progress__item[data-state="active"],
+    %s .fp-progress__item[data-progress-state="active"],
+    %s .fp-progress__item:focus-visible {
+        --fp-progress-item-padding-inline: 0.65rem;
+        --fp-progress-item-min-width: min(72vw, 10.75rem);
+        --fp-progress-label-gap: 0.5rem;
+        --fp-progress-label-max-width: min(68vw, 10.25rem);
+    }
+    %s .fp-progress__item[data-state="active"] .fp-progress__label,
+    %s .fp-progress__item[data-progress-state="active"] .fp-progress__label,
+    %s .fp-progress__item:focus-visible .fp-progress__label {
+        white-space: normal;
+    }
+    %s .fp-meals__list {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        padding-bottom: 0.25rem;
+    }
+    %s .fp-meal-pill {
+        flex: 0 0 auto;
     }
 }
 CSS;

--- a/templates/frontend/form.php
+++ b/templates/frontend/form.php
@@ -283,6 +283,7 @@ endif;
                                                     data-fp-resv-meal="<?php echo esc_attr($mealKey); ?>"
                                                     data-meal-label="<?php echo esc_attr($mealLabel); ?>"
                                                     data-meal-notice="<?php echo esc_attr($mealNotice); ?>"
+                                                    data-meal-default-notice="<?php echo esc_attr($mealNotice); ?>"
                                                     data-meal-price="<?php echo esc_attr($mealPrice); ?>"
                                                     <?php echo $isActive ? 'data-active="true" aria-pressed="true"' : 'aria-pressed="false"'; ?>
                                                 >
@@ -301,7 +302,11 @@ endif;
                                             data-fp-resv-meal-notice
                                             <?php echo $defaultMealNotice === '' ? 'hidden' : ''; ?>
                                         >
-                                            <?php echo esc_html($defaultMealNotice); ?>
+                                            <span class="fp-meals__notice-icon" aria-hidden="true">i</span>
+                                            <em
+                                                class="fp-meals__notice-text"
+                                                data-fp-resv-meal-notice-text
+                                            ><?php echo esc_html($defaultMealNotice); ?></em>
                                         </p>
                                     </section>
                                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- define the shared focus ring variable so inline styling can reuse the compiled focus shadow
- mirror honeypot, field, hint, and input control rules from form.css including checkbox behaviour
- align the inline slot list, status, and button states with the compiled stylesheet selectors

## Testing
- php -l src/Domain/Settings/Style.php

------
https://chatgpt.com/codex/tasks/task_e_68e268de2880832f8ec4c440d7d60bb7