### PR TITLE
Adjust form margin for mobile view

### DIFF
--- a/assets/css/form.css
+++ b/assets/css/form.css
@@ -1325,11 +1325,11 @@
 
 @media (max-width: 640px) {
     .fp-resv {
-        padding: 1.35rem;
+        padding: 0.75rem;
     }
 
     #fp-resv-default.fp-resv-widget {
-        padding: 1rem !important;
+        padding: 0.5rem !important;
     }
 
     .fp-progress {


### PR DESCRIPTION
Reduce horizontal padding for the form to make it appear larger on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-833f8ded-31e3-4fa7-8578-c07d34835a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-833f8ded-31e3-4fa7-8578-c07d34835a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

