### PR TITLE
Ensure reservation shortcode renders even when theme skips processing

### DIFF
--- a/src/Frontend/Shortcodes.php
+++ b/src/Frontend/Shortcodes.php
@@ -17,6 +17,8 @@ use function shortcode_atts;
 
 final class Shortcodes
 {
+    private static bool $rendered = false;
+
     public static function register(): void
     {
         add_shortcode('fp_reservations', [self::class, 'render']);
@@ -114,6 +116,7 @@ final class Shortcodes
             }
 
             error_log('[FP-RESV] Form renderizzato correttamente, lunghezza output: ' . strlen($output));
+            self::$rendered = true;
             return $output;
         } catch (\Throwable $e) {
             // Log error in development/debug mode
@@ -161,5 +164,10 @@ final class Shortcodes
         ];
 
         return self::render($atts);
+    }
+
+    public static function hasRendered(): bool
+    {
+        return self::$rendered;
     }
 }


### PR DESCRIPTION
## Summary
- track when the reservation shortcode successfully renders to detect missing widgets
- inject a fallback rendering in the footer when the shortcode is present but no widget markup was produced
- parse shortcode attributes from post content to mirror original shortcode configuration during fallback

## Testing
- php -l src/Frontend/Shortcodes.php
- php -l src/Frontend/WidgetController.php

------
https://chatgpt.com/codex/tasks/task_e_68eb81065a68832f87faa030bdada008