### PR TITLE
Fix frontend form styling to match the fork aesthetic

### DIFF
--- a/assets/css/form.css
+++ b/assets/css/form.css
@@ -15,8 +15,8 @@
 /* Importa il bridge per compatibilità tra sistemi di variabili */
 @import './form/_variables-bridge.css';
 
-/* Importa il sistema completo The Fork Style */
-@import './form-thefork-bw.css';
+/* Importa il sistema completo The Fork Style (palette verde TheFork) */
+@import './form-thefork.css';
 
 /* ==================== NOTE IMPORTANTI ==================== */
 

--- a/src/Domain/Settings/Style.php
+++ b/src/Domain/Settings/Style.php
@@ -37,9 +37,10 @@ final class Style
     public function getDefaults(): array
     {
         return [
-            'style_palette'          => 'neutral', // B/W palette di default
-            'style_primary_color'    => '#000000', // Nero di default
-            'style_button_bg'        => '#000000', // Bottoni neri
+            // Default estetica TheFork: verde premium
+            'style_palette'          => 'brand',
+            'style_primary_color'    => '#2db77e', // Verde TheFork
+            'style_button_bg'        => '#2db77e', // Bottoni verdi
             'style_button_text'      => '#ffffff', // Testo bianco
             'style_font_family'      => '"Inter", sans-serif',
             'style_font_size'        => '16',


### PR DESCRIPTION
Switch form CSS import and update default palette to correctly apply The Fork aesthetic.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf5d8733-a41b-4918-9bb9-dcea1e2541ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf5d8733-a41b-4918-9bb9-dcea1e2541ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

